### PR TITLE
Use apache user/group for carbon storage

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -36,7 +36,7 @@ template "#{node['graphite']['base_dir']}/conf/storage-schemas.conf" do
 end
 
 execute "carbon: change graphite storage permissions to apache user" do
-  command "chown -R www-data:www-data #{node['graphite']['base_dir']}/storage"
+  command "chown -R #{node['apache']['user']}:#{node['apache']['group']} #{node['graphite']['base_dir']}/storage"
   only_if do
     f = File.stat("#{node['graphite']['base_dir']}/storage")
     f.uid == 0 and f.gid == 0


### PR DESCRIPTION
Quick fix to make sure the user/group used for the carbon storage matches what was configured in the apache cookbook.
