### PR TITLE
Add AMQP configuration support

### DIFF
--- a/attributes/graphite.rb
+++ b/attributes/graphite.rb
@@ -32,4 +32,14 @@ default['graphite']['carbon']['max_updates_per_second'] = 1000
 default['graphite']['carbon']['service_type'] = "runit"
 default['graphite']['carbon']['log_whisper_updates'] = "False"
 
+# Default carbon AMQP settings match the carbon default config
+default['graphite']['carbon']['enable_amqp'] = false
+default['graphite']['carbon']['amqp_host'] = "localhost"
+default['graphite']['carbon']['amqp_port'] = 5672
+default['graphite']['carbon']['amqp_vhost'] = "/"
+default['graphite']['carbon']['amqp_user'] = "guest"
+default['graphite']['carbon']['amqp_password'] = "guest"
+default['graphite']['carbon']['amqp_exchange'] = "graphite"
+default['graphite']['carbon']['amqp_metric_name_in_body'] = false
+
 default['graphite']['encrypted_data_bag']['name'] = nil

--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -20,6 +20,10 @@
 package "python-twisted"
 package "python-simplejson"
 
+if node['graphite']['carbon']['enable_amqp']
+    package "python-txamqp"
+end
+
 version = node['graphite']['version']
 pyver = node['languages']['python']['version'][0..-3]
 
@@ -51,6 +55,14 @@ template "#{node['graphite']['base_dir']}/conf/carbon.conf" do
              :cache_query_port => node['graphite']['carbon']['cache_query_port'],
              :max_updates_per_second => node['graphite']['carbon']['max_updates_per_second'],
              :log_whisper_updates => node['graphite']['carbon']['log_whisper_updates'],
+             :enable_amqp => node['graphite']['carbon']['enable_amqp'],
+             :amqp_host => node['graphite']['carbon']['amqp_host'],
+             :amqp_port => node['graphite']['carbon']['amqp_port'],
+             :amqp_vhost => node['graphite']['carbon']['amqp_vhost'],
+             :amqp_user => node['graphite']['carbon']['amqp_user'],
+             :amqp_password => node['graphite']['carbon']['amqp_password'],
+             :amqp_exchange => node['graphite']['carbon']['amqp_exchange'],
+             :amqp_metric_name_in_body => node['graphite']['carbon']['amqp_metric_name_in_body'],
              :storage_dir => node['graphite']['storage_dir'])
   notifies :restart, "service[carbon-cache]"
 end

--- a/templates/default/carbon.conf.erb
+++ b/templates/default/carbon.conf.erb
@@ -42,18 +42,32 @@ LOG_UPDATES = <%= @log_whisper_updates %>
 
 
 # Enable AMQP if you want to receve metrics using an amqp broker
+<% if @enable_amqp %>
+ENABLE_AMQP = True
+<% else %>
 # ENABLE_AMQP = False
+<% end %>
 
 # Verbose means a line will be logged for every metric received
 # useful for testing
 # AMQP_VERBOSE = False
 
+<% if @enable_amqp %>
+AMQP_HOST = <%= @amqp_host %>
+AMQP_PORT = <%= @amqp_port %>
+AMQP_VHOST = <%= @amqp_vhost %>
+AMQP_USER = <%= @amqp_user %>
+AMQP_PASSWORD = <%= @amqp_password %>
+AMQP_EXCHANGE = <%= @amqp_exchange %>
+AMQP_METRIC_NAME_IN_BODY = <%= @amqp_metric_name_in_body ? "True" : "False" %>
+<% else %>
 # AMQP_HOST = localhost
 # AMQP_PORT = 5672
 # AMQP_VHOST = /
 # AMQP_USER = guest
 # AMQP_PASSWORD = guest
 # AMQP_EXCHANGE = graphite
+<% end %>
 
 # Patterns for all of the metrics this machine will store. Read more at
 # http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Bindings


### PR DESCRIPTION
Default attributes match default carbon-cache settings.

I also incorporated your feedback to use an if-else block in the carbon.conf.erb file.

If a user upgrades to this version of the cookbook from a previous version the carbon.conf file _will not_ change, therefore carbon-cache will not be restarted as a result of this change.  Unless of course enable_amqp is set to true :smile:.
