### PR TITLE
Pin memcached to avoid runit version conflict

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ supports "fedora"
 depends  "python"
 depends  "apache2"
 depends  "runit", "<= 0.16.2"
-depends  "memcached"
+depends  "memcached", "<= 1.2.0"
 
 suggests "systemd"
 suggests "s6"


### PR DESCRIPTION
memcached cookbook 1.3.0 and newer depend on runit 1.0
