### PR TITLE
Uncomment all the tuneables in the web config

### DIFF
--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -12,12 +12,12 @@
 TIME_ZONE = '<%= @timezone %>'
 
 # Override this to provide documentation specific to your Graphite deployment
-#DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
+DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
 
 # Logging
-#LOG_RENDERING_PERFORMANCE = True
-#LOG_CACHE_PERFORMANCE = True
-#LOG_METRIC_ACCESS = True
+LOG_RENDERING_PERFORMANCE = True
+LOG_CACHE_PERFORMANCE = True
+LOG_METRIC_ACCESS = True
 
 # Enable full debug page display on exceptions (Internal Server Error pages)
 #DEBUG = True
@@ -43,28 +43,28 @@ MEMCACHE_HOSTS = ['127.0.0.1:11211']
 #####################################
 # Change only GRAPHITE_ROOT if your install is merely shifted from /opt/graphite
 # to somewhere else
-#GRAPHITE_ROOT = '<%= @base_dir %>'
+GRAPHITE_ROOT = '<%= @base_dir %>'
 # Most installs done outside of a separate tree such as /opt/graphite will only
 # need to change these three settings. Note that the default settings for each
 # of these is relative to GRAPHITE_ROOT
-#CONF_DIR = '<%= @base_dir %>/conf'
+CONF_DIR = '<%= @base_dir %>/conf'
 STORAGE_DIR = '<%= @storage_dir %>'
-#CONTENT_DIR = '<%= @doc_root %>/content'
+CONTENT_DIR = '<%= @doc_root %>/content'
 
 # To further or fully customize the paths, modify the following. Note that the
 # default settings for each of these are relative to CONF_DIR and STORAGE_DIR
 #
 ## Webapp config files
-#DASHBOARD_CONF = '<%= @base_dir %>/conf/dashboard.conf'
-#GRAPHTEMPLATES_CONF = '<%= @base_dir %>/conf/graphTemplates.conf'
+DASHBOARD_CONF = '<%= @base_dir %>/conf/dashboard.conf'
+GRAPHTEMPLATES_CONF = '<%= @base_dir %>/conf/graphTemplates.conf'
 
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
-#WHISPER_DIR = '<%= @storage_dir %>/whisper'
-#RRD_DIR = '<%= @storage_dir %>/rrd'
-#DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
-#LOG_DIR = '<%= @storage_dir %>/log/webapp'
-#INDEX_FILE = '<%= @storage_dir %>/index'  # Search index file
+WHISPER_DIR = '<%= @storage_dir %>/whisper'
+RRD_DIR = '<%= @storage_dir %>/rrd'
+DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
+LOG_DIR = '<%= @storage_dir %>/log/webapp'
+INDEX_FILE = '<%= @storage_dir %>/index'  # Search index file
 
 
 #####################################


### PR DESCRIPTION
The commented out metrics are the defaults and we have attributes for
these.  Why not uncomment so you can set non-defaults
