### PR TITLE
[carbon] service resource based on attribute instead of platform_family

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -44,8 +44,8 @@ execute "install carbon" do
   cwd "#{Chef::Config[:file_cache_path]}/carbon-#{version}"
 end
 
-case node['platform_family']
-when "debian"
+case node['graphite']['carbon']['service_type']
+when "runit"
   carbon_cache_service_resource = "runit_service[carbon-cache]"
 else
   carbon_cache_service_resource = "service[carbon-cache]"


### PR DESCRIPTION
Using service_type instead of platform_family here makes more sense
