### PR TITLE
use python_pip to install the same recent txAMQP lib for all platforms

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -21,7 +21,9 @@ package "python-twisted"
 package "python-simplejson"
 
 if node['graphite']['carbon']['enable_amqp']
-    package "python-txamqp"
+  python_pip "txamqp" do
+    action :install
+  end
 end
 
 version = node['graphite']['version']


### PR DESCRIPTION
See https://github.com/hw-cookbooks/graphite/issues/27.

Validated on all vagrant VMs ('cept for centos 5.8 which I disabled).

Tested this by also installing rabbitmq cookbook and sending metrics from a ruby-amqp test client on my local machine. On Ubuntu 10.04, the rabbitmq version is old so ruby-amqp failed to connect (but graphite did ;-)

Would have to see if/how this can be added to tests - along with testing a metric via TCP.
