### PR TITLE
Django database settings missing

### DIFF
--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -136,17 +136,17 @@ INDEX_FILE = '<%= @storage_dir %>/index'  # Search index file
 #
 # Users with Django 1.2 or greater should use the new dictionary
 # specification as the old database specification style is removed in 1.4
-#DATABASES = {
-#    'default': {
-#        'NAME': '<%= @storage_dir %>/graphite.db',
-#        'ENGINE': 'django.db.backends.sqlite3',
-#        'USER': '',
-#        'PASSWORD': '',
-#        'HOST': '',
-#        'PORT': ''
-#    }
-#}
-#
+DATABASES = {
+    'default': {
+        'NAME': '<%= @storage_dir %>/graphite.db',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': ''
+    }
+}
+
 # Users still on Django 1.1 must use the old method instead:
 #DATABASE_ENGINE = 'django.db.backends.mysql'
 #DATABASE_NAME = 'graphite'      # Or path to the database file if using sqlite3


### PR DESCRIPTION
When doing a fresh install, django complains of missing DATABASES configuration.

This change fixes the issue.
