### PR TITLE
support alternate install location for carbon, whisper and graphite-web 

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -41,7 +41,7 @@ execute "untar carbon" do
 end
 
 execute "install carbon" do
-  command "python setup.py install"
+  command "python setup.py install --prefix=#{node['graphite']['base_dir']} --install-lib=#{node['graphite']['base_dir']}/lib"
   creates "#{node['graphite']['base_dir']}/lib/carbon-#{version}-py#{pyver}.egg-info"
   cwd "#{Chef::Config[:file_cache_path]}/carbon-#{version}"
 end

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -60,7 +60,7 @@ execute "untar graphite-web" do
 end
 
 execute "install graphite-web" do
-  command "python setup.py install"
+  command "python setup.py install --prefix=#{node['graphite']['base_dir']} --install-lib=#{node['graphite']['doc_root']}"
   creates "#{node['graphite']['doc_root']}/graphite_web-#{version}-py#{pyver}.egg-info"
   cwd "#{Chef::Config[:file_cache_path]}/graphite-web-#{version}"
 end

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -32,7 +32,7 @@ execute "untar whisper" do
 end
 
 execute "install whisper" do
-  command "python setup.py install"
+  command "python setup.py install --prefix=#{node['graphite']['base_dir']} --install-lib=#{node['graphite']['base_dir']}/lib"
   creates "/usr/local/lib/python#{pyver}/dist-packages/whisper-#{version}.egg-info"
   cwd "#{Chef::Config[:file_cache_path]}/whisper-#{version}"
 end


### PR DESCRIPTION
Fix that updates the python package builds to use prefix and install-lib options with the seutp.py script. These changes were tested on ubuntu 12. 
