### PR TITLE
graphite::carbon python_pip "txamqp" fails without include_recipe "python::pip"

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -21,6 +21,7 @@ package "python-twisted"
 package "python-simplejson"
 
 if node['graphite']['carbon']['enable_amqp']
+  include_recipe "python::pip"
   python_pip "txamqp" do
     action :install
   end


### PR DESCRIPTION
this ensures that pip is installed.
