### PR TITLE
Fix admin username and password args

### DIFF
--- a/templates/default/set_admin_passwd.py.erb
+++ b/templates/default/set_admin_passwd.py.erb
@@ -7,8 +7,8 @@ sys.path.append("<%= node['graphite']['doc_root']%>/graphite")
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 from django.contrib.auth.models import User
 
-username = sys.argv[1]
-password = sys.argv[2]
+username = sys.argv[0]
+password = sys.argv[1]
 
 try:
     u = User.objects.get(username__exact=username)


### PR DESCRIPTION
Seems like https://github.com/hw-cookbooks/graphite/blob/master/recipes/web.rb#L111 is passing only two args so should this not be sys.argv[0] and sys.argv[1]?
