### PR TITLE
Explicitly install zope.interface, which Twisted requires

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -20,8 +20,13 @@
 package "python-twisted"
 package "python-simplejson"
 
+include_recipe "python::pip"
+
+python_pip "zope.interface>=3.6.0" do
+  action :install
+end
+
 if node['graphite']['carbon']['enable_amqp']
-  include_recipe "python::pip"
   python_pip "txamqp" do
     action :install
   end


### PR DESCRIPTION
Needed this on the latest Amazon Linux.  Otherwise you get this error:

```
Recipe: graphite::carbon_init
  * service[carbon-cache] action restart
================================================================================
Error executing action `restart` on resource 'service[carbon-cache]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /sbin/service carbon-cache start ----
STDOUT: Starting carbon-cache...
Carbon-Cache did not start successfully
See /var/log/carbon-cache/carbon-cache.log for details
STDERR:
---- End output of /sbin/service carbon-cache start ----
Ran /sbin/service carbon-cache start returned 1


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/graphite/recipes/carbon_init.rb

 10: service "carbon-cache" do
 11:   action [:enable, :start]
 12: end



Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/graphite/recipes/carbon_init.rb:10:in `from_file'

service("carbon-cache") do
  action [:enable, :start]
  updated true
  supports {:restart=>false, :reload=>false, :status=>true}
  retries 0
  retry_delay 2
  service_name "carbon-cache"
  enabled true
  running true
  pattern "carbon-cache"
  startup_type :automatic
  cookbook_name "graphite"
  recipe_name "carbon_init"
end



[2013-05-03T21:18:56+00:00] ERROR: Running exception handlers
[2013-05-03T21:18:56+00:00] FATAL: Saving node information to /var/chef/cache/failed-run-data.json
[2013-05-03T21:18:56+00:00] ERROR: Exception handlers complete
Chef Client failed. 17 resources updated
[2013-05-03T21:18:56+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-05-03T21:18:56+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: service[carbon-cache] (graphite::carbon_init line 10) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of /sbin/service carbon-cache start ----
STDOUT: Starting carbon-cache...
Carbon-Cache did not start successfully
See /var/log/carbon-cache/carbon-cache.log for details
STDERR:
---- End output of /sbin/service carbon-cache start ----
Ran /sbin/service carbon-cache start returned 1
[ec2-user@graphite ~]$ cat /var/log/carbon-cache/carbon-cache.log
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-cache.py", line 28, in <module>
    from carbon.util import run_twistd_plugin
  File "/opt/graphite/lib/carbon/util.py", line 17, in <module>
    from twisted.python.util import initgroups
  File "/opt/graphite/lib/twisted/__init__.py", line 53, in <module>
    _checkRequirements()
  File "/opt/graphite/lib/twisted/__init__.py", line 51, in _checkRequirements
    raise ImportError(required + ".")
ImportError: Twisted requires zope.interface 3.6.0 or later.


```
