### PR TITLE
Fixing PID file

### DIFF
--- a/templates/default/sv-carbon-cache-run.erb
+++ b/templates/default/sv-carbon-cache-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= node['graphite']['user_account'] %> -l <%= node['graphite']['storage_dir'] %>/carbon-cache.lock -- <%= node['graphite']['base_dir']%>/bin/carbon-cache.py --debug start
+exec chpst -u <%= node['graphite']['user_account'] %> -l <%= node['graphite']['storage_dir'] %>/carbon-cache.lock -- <%= node['graphite']['base_dir']%>/bin/carbon-cache.py --pid <%= node['graphite']['storage_dir'] %>/carbon-cache-a.pid --debug start


### PR DESCRIPTION
When the storage_dir is set to another location the proccess doesn't have permissions to write to /opt/graphite/storage, so carbon-cache fails trying to write the PID file
