### PR TITLE
Bring carbon upstart recipes into line for ea27d1a

### DIFF
--- a/recipes/carbon_cache_upstart.rb
+++ b/recipes/carbon_cache_upstart.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: graphite
-# Recipe:: carbon_upstart
+# Recipe:: carbon_cache_upstart
 #
 # Copyright 2013, Heavy Water Software Inc.
 #
@@ -19,8 +19,9 @@
 
 
 template "/etc/init/carbon-cache.conf" do
-  source "carbon-cache.upstart.erb"
+  source "carbon.upstart.erb"
   variables(
+    :name    => 'cache',
     :dir     => node['graphite']['base_dir'],
     :user    => node['apache']['user']
   )

--- a/recipes/carbon_relay_upstart.rb
+++ b/recipes/carbon_relay_upstart.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: graphite
+# Recipe:: carbon_relay_upstart
+#
+# Copyright 2013, Heavy Water Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+template "/etc/init/carbon-relay.conf" do
+  source "carbon.upstart.erb"
+  variables(
+    :name    => 'relay',
+    :dir     => node['graphite']['base_dir'],
+    :user    => node['apache']['user']
+  )
+  mode 00644
+end
+
+service "carbon-relay" do
+  provider Chef::Provider::Service::Upstart
+  supports :restart => true, :status => true
+  action [:enable, :start]
+end

--- a/templates/default/carbon.upstart.erb
+++ b/templates/default/carbon.upstart.erb
@@ -1,7 +1,7 @@
 #!upstart
 # http://upstart.ubuntu.com/cookbook/
 #
-description carbon-cache
+description carbon-<%= @name %>
 
 start on runlevel [2345]
 stop on shutdown
@@ -13,4 +13,4 @@ respawn limit 99 5
 
 setuid <%= @user %>
 
-exec <%= @dir %>/bin/carbon-cache.py start
+exec <%= @dir %>/bin/carbon-<%= @name %>.py start


### PR DESCRIPTION
ea27d1a broke upstart support, since upstart was omitted from that PR.  This brings upstart into line with the new code.  I'm not sure I really see the point in removing init script duplication, only to introduce recipe duplication, but that's an aside, and maybe I'm missing the point there.  Anyway, this makes upstart work again, which is what my env needed.
