### PR TITLE
Add basic_auth attributes to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ graphite-web attributes
 * `node['graphite']['ssl']['certificate_file']` - the path to the certificate file if ssl is enabled
 * `node['graphite']['ssl']['certificate_key_file']` - the path to the vertificate key file if ssl is enabled
 * `node['graphite']['apache']['basic_auth']['enabled']` - enable basic auth in the apache2 vhost to require authentication for access to web interface (defaults to false)
-* `default['graphite']['apache']['basic_auth']['file_path']` - location of htpasswd file for basic auth (defaults to node['graphite']['doc_root']/htpasswd)
-* `default['graphite']['apache']['basic_auth']['user']` - username for basic auth
-* `default['graphite']['apache']['basic_auth']['pass']` - password for basic auth
+* `node['graphite']['apache']['basic_auth']['file_path']` - location of htpasswd file for basic auth (defaults to node['graphite']['doc_root']/htpasswd)
+* `node['graphite']['apache']['basic_auth']['user']` - username for basic auth
+* `node['graphite']['apache']['basic_auth']['pass']` - password for basic auth
 
 storage_schemas example
 -----------------------


### PR DESCRIPTION
Apache recipe and vhost template support basic auth. These commits add documentation of the relevant attributes to the readme.
