### PR TITLE
add include_attribute for apache2 to default attributes file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,8 @@
 # Attributes:: default
 #
 
+include_attribute "apache2"
+
 default['graphite']['version'] = "0.9.10"
 default['graphite']['password'] = "change_me"
 default['graphite']['chef_role'] = "graphite"


### PR DESCRIPTION
Per http://docs.opscode.com/essentials_cookbook_attribute_files.html#attribute-file-ordering,
an include_attribute line is necessary to ensure node['apache'] will be filled out with the apache2 cookbook's defaults.rb.
