### PR TITLE
This is solving whisper install idempotency

### DIFF
--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -19,6 +19,7 @@
 
 version = node['graphite']['version']
 pyver = node['languages']['python']['version'][0..-3]
+install_lib_dir = "#{node['graphite']['base_dir']}/lib"
 
 remote_file "#{Chef::Config[:file_cache_path]}/whisper-#{version}.tar.gz" do
   source node['graphite']['whisper']['uri']
@@ -32,8 +33,8 @@ execute "untar whisper" do
 end
 
 execute "install whisper" do
-  command "python setup.py install --prefix=#{node['graphite']['base_dir']} --install-lib=#{node['graphite']['base_dir']}/lib"
-  creates "/usr/local/lib/python#{pyver}/dist-packages/whisper-#{version}.egg-info"
+  command "python setup.py install --prefix=#{node['graphite']['base_dir']} --install-lib=#{install_lib_dir}"
+  creates "#{install_lib_dir}/whisper-#{version}-py#{pyver}.egg-info"
   cwd "#{Chef::Config[:file_cache_path]}/whisper-#{version}"
 end
 


### PR DESCRIPTION
Previously "creates" attribute of "install whisper" execute resource
was pointint to a completely different path than to which --install-lib switch
is pointing to thus breaking "install whisper" execute resource's
idempotency. This is now fixed with this patch.
