### PR TITLE
fix enable_amqp template bug

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -26,11 +26,10 @@ if node['graphite']['carbon']['enable_amqp']
     action :install
   end
 
-  amqp_password = node['graphite']['carbon']['amqp_password']
   if node['graphite']['encrypted_data_bag']['name']
     data_bag_name = node['graphite']['encrypted_data_bag']['name']
     data_bag_item = Chef::EncryptedDataBagItem.load(data_bag_name, 'graphite')
-    amqp_password = data_bag_item['amqp_password']
+    node['graphite']['carbon']['amqp_password'] = data_bag_item['amqp_password']
   else
     Chef::Log.warn "This recipe uses encrypted data bags for carbon AMQP password but no encrypted data bag name is specified - fallback to node attribute."
   end
@@ -59,10 +58,8 @@ end
 template "#{node['graphite']['base_dir']}/conf/carbon.conf" do
   owner node['graphite']['user_account']
   group node['graphite']['group_account']
-  carbon_options = node['graphite']['carbon'].dup
-  carbon_options['amqp_password'] = amqp_password unless amqp_password.nil?
   variables( :storage_dir => node['graphite']['storage_dir'],
-             :carbon_options => carbon_options
+             :carbon_options => node['graphite']['carbon']
   )
 end
 


### PR DESCRIPTION
if we enable_amqp and set amqp_password in node attributes - then Line 63 
           "carbon_options['amqp_password'] = amqp_password unless amqp_password.nil?" 
causes recipe to fail when generating template.

This patch fixes it, and eliminates local variable amqp_password.
