### PR TITLE
fix change ownership bug on NFS-mounted filesystems

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -45,7 +45,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/carbon-#{version}.tar.gz" do
 end
 
 execute "untar carbon" do
-  command "tar xzf carbon-#{version}.tar.gz"
+  command "tar --no-same-owner xzf carbon-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/carbon-#{version}"
   cwd Chef::Config[:file_cache_path]
 end

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -76,7 +76,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/graphite-web-#{version}.tar.gz" d
 end
 
 execute "untar graphite-web" do
-  command "tar xzf graphite-web-#{version}.tar.gz"
+  command "tar --no-same-owner xzf graphite-web-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/graphite-web-#{version}"
   cwd Chef::Config[:file_cache_path]
 end

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -27,7 +27,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/whisper-#{version}.tar.gz" do
 end
 
 execute "untar whisper" do
-  command "tar xzf whisper-#{version}.tar.gz"
+  command "tar --no-same-owner xzf whisper-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/whisper-#{version}"
   cwd Chef::Config[:file_cache_path]
 end


### PR DESCRIPTION
Hello there,

We were running into issues with the cookbook some VMs using an NFS-mounted filesystem. The tar commands issued would throw a "Cannot change ownership" bug. This bug is mentioned on http://leopard.in.ua/2013/01/12/chef-solo-getting-started-part-4/ where the --no-same-owner flag is proposed as a solution.

We managed to get everything to work with this solution.

Greetings
