### PR TITLE
repair tar command for some versions of tar

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -45,7 +45,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/carbon-#{version}.tar.gz" do
 end
 
 execute "untar carbon" do
-  command "tar --no-same-owner xzf carbon-#{version}.tar.gz"
+  command "tar xzof carbon-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/carbon-#{version}"
   cwd Chef::Config[:file_cache_path]
 end

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -76,7 +76,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/graphite-web-#{version}.tar.gz" d
 end
 
 execute "untar graphite-web" do
-  command "tar --no-same-owner xzf graphite-web-#{version}.tar.gz"
+  command "tar xzof graphite-web-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/graphite-web-#{version}"
   cwd Chef::Config[:file_cache_path]
 end

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -27,7 +27,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/whisper-#{version}.tar.gz" do
 end
 
 execute "untar whisper" do
-  command "tar --no-same-owner xzf whisper-#{version}.tar.gz"
+  command "tar xzof whisper-#{version}.tar.gz"
   creates "#{Chef::Config[:file_cache_path]}/whisper-#{version}"
   cwd Chef::Config[:file_cache_path]
 end


### PR DESCRIPTION
The previous pull request broke some versions of tar which rely on specific ordering of options.
This commit fixes this issue.
