### PR TITLE
storage-aggregation.conf belongs to carbon-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ carbon-cache.py attributes
 --------------------------
 
 * `node['graphite']['storage_schemas']` - an array with retention rates for storing metrics, used to generate the *storage-schemas.conf* file ([see the example below](#storage_schemas-example))
+* `node['graphite']['storage_aggregation']` - an array with rules to configure how to aggregate data to lower-precision retentions, used to generate the *storage-aggregation.conf* file
 * `node['graphite']['carbon']['uri']` - download url for carbon
 * `node['graphite']['carbon']['checksum']` - checksum for the carbon download
 * `node['graphite']['carbon']['line_receiver_interface']` - line interface IP (defaults to 0.0.0.0)
@@ -71,7 +72,6 @@ carbon-relay.py attributes
 carbon-aggregator.py attributes
 -------------------------------
 
-* `node['graphite']['storage_aggregation']` - an array with rules to configure how to aggregate data to lower-precision retentions, used to generate the *storage-aggregation.conf* file
 * `node['graphite']['aggregation_rules']` - an array with rules that allow you to add several metrics together, used to generate the *aggregation-rules.conf* file ([see the example below](#aggregation_rules-example))
 * `node['graphite']['carbon']['aggregator']['line_receiver_interface']` - line interface IP (defaults to 0.0.0.0)
 * `node['graphite']['carbon']['aggregator']['line_receiver_port']` - line interface port (defaults to 2023)

--- a/attributes/carbon_aggregator.rb
+++ b/attributes/carbon_aggregator.rb
@@ -14,6 +14,5 @@ default['graphite']['carbon']['aggregator']['use_flow_control'] = "True"
 default['graphite']['carbon']['aggregator']['max_datapoints_per_message'] = 500
 default['graphite']['carbon']['aggregator']['max_aggregation_intervals'] = 5
 
-default['graphite']['storage_aggregation'] = nil
 default['graphite']['aggregation_rules'] = []
 

--- a/attributes/carbon_cache.rb
+++ b/attributes/carbon_cache.rb
@@ -22,11 +22,12 @@ default['graphite']['carbon']['whisper_autoflush'] = "False"
 
 default['graphite']['storage_schemas'] = [
   {
-    'name' => 'catchall', 
-    'pattern' => '^.*', 
+    'name' => 'catchall',
+    'pattern' => '^.*',
     'retentions' => '60:100800,900:63000'
   }
 ]
+default['graphite']['storage_aggregation'] = nil
 
 case node['platform_family']
 when "debian"

--- a/recipes/carbon_aggregator.rb
+++ b/recipes/carbon_aggregator.rb
@@ -26,21 +26,6 @@ else
   carbon_aggregator_service_resource = 'service[carbon-aggregator]'
 end
 
-if node['graphite']['storage_aggregation'].is_a?(Array) and node['graphite']['storage_aggregation'].length > 0
-  template "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf" do
-    source 'storage.conf.erb'
-    owner node['graphite']['user_account']
-    group node['graphite']['group_account']
-    variables( :storage_config => node['graphite']['storage_aggregation'] )
-    notifies :restart, carbon_aggregator_service_resource
-  end
-else
-  file "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf" do
-    action :delete
-    notifies :restart, carbon_aggregator_service_resource
-  end
-end
-
 # aggregation-rules.conf file is automatically reloaded by the carbon-aggregator process.
 # There is no need to restart the application.
 if node['graphite']['aggregation_rules'].is_a?(Array) and node['graphite']['aggregation_rules'].length > 0

--- a/recipes/carbon_cache.rb
+++ b/recipes/carbon_cache.rb
@@ -34,4 +34,19 @@ template "#{node['graphite']['base_dir']}/conf/storage-schemas.conf" do
   notifies :restart, carbon_cache_service_resource
 end
 
+if node['graphite']['storage_aggregation'].is_a?(Array) and node['graphite']['storage_aggregation'].length > 0
+  template "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf" do
+    source 'storage.conf.erb'
+    owner node['graphite']['user_account']
+    group node['graphite']['group_account']
+    variables( :storage_config => node['graphite']['storage_aggregation'] )
+    notifies :restart, carbon_cache_service_resource
+  end
+else
+  file "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf" do
+    action :delete
+    notifies :restart, carbon_cache_service_resource
+  end
+end
+
 include_recipe "#{cookbook_name}::#{recipe_name}_#{service_type}"


### PR DESCRIPTION
As pointed out by issue https://github.com/hw-cookbooks/graphite/issues/93, the storage-aggregation.conf belongs to carbon_cache.
