### PR TITLE
create missing rrd folder

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -72,7 +72,7 @@ directory node['graphite']['storage_dir'] do
   recursive true
 end
 
-%w{ log whisper }.each do |dir|
+%w{ log whisper rrd }.each do |dir|
   directory "#{node['graphite']['storage_dir']}/#{dir}" do
     owner node['graphite']['user_account']
     group node['graphite']['group_account']


### PR DESCRIPTION
Fixes Issue #97
Create rrd folder using the base storage directory.
