### PR TITLE
Fix federated recipe

### DIFF
--- a/recipes/federated.rb
+++ b/recipes/federated.rb
@@ -58,11 +58,8 @@ else
       end
 
       node.default['graphite']['carbon']['relay']['destinations'] = destinations
+      node.default['graphite']['graphite_web']['carbonlink_hosts'] = destinations
       node.default['graphite']['graphite_web']['cluster_servers'] = cluster_servers
-
-      node.default['graphite']['graphite_web']['carbonlink_hosts'] = [
-        "#{result['fqdn']}:#{node['graphite']['carbon']['cache_query_port']}:a",
-      ]
     end
   end
 end


### PR DESCRIPTION
The first commit keeps the knife search consistent across nodes because order matters. 

The second commit fixes the recipe because it was previously broken. "result" was being referenced outside the block where it was no longer available. 
