### PR TITLE
fix daemon syntax on rhel platforms #122

### DIFF
--- a/templates/default/carbon.init.erb
+++ b/templates/default/carbon.init.erb
@@ -47,7 +47,11 @@ start() {
 
     echo -e "\033[1mStarting carbon-<%= @name %>-$INSTANCE...\033[0m"
     cd /tmp
+    <% if node[:platform_family] == "rhel" %>
+    daemon --user $CC_USER ${!BIN_SCRIPT}
+    <% else %>
     daemon --user $CC_USER -- ${!BIN_SCRIPT}
+    <% end %>
     result=$?
 
     if [ $result -ne 0 ] ; then


### PR DESCRIPTION
confirmed working on Amazon Linux.  Not tested on other platforms.  Your mileage may vary.
