### PR TITLE
Added runit support for running multiple carbon-cache daemons

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -106,3 +106,45 @@ suites:
   run_list:
   - recipe[graphite::federated]
   attributes: {}
+- name: carbon-cache
+  run_list:
+  - recipe[graphite]
+  - recipe[graphite::carbon_cache]
+  attributes: {
+    "graphite": {
+      "carbon": {
+        "caches": {
+          "a": {
+            "line_reciever_port": 2003,
+            "udp_receiver_port": 2003,
+            "pickle_receiver_port": 2004,
+            "cache_query_port": 7002,
+            "line_receiver_interface": 0.0.0.0,
+            "udp_receiver_interface": 0.0.0.0,
+            "pickle_receiver_interface": 0.0.0.0,
+            "cache_query_interface": 0.0.0.0
+          },
+          "b": {
+            "line_receiver_port": 2005,
+            "udp_receiver_port": 2005,
+            "pickle_receiver_port": 2006,
+            "cache_query_port": 7003,
+            "line_receiver_interface": 0.0.0.0,
+            "udp_receiver_interface": 0.0.0.0,
+            "pickle_receiver_interface": 0.0.0.0,
+            "cache_query_interface": 0.0.0.0
+          },
+          "c": {
+            "line_receiver_port": 2007,
+            "udp_receiver_port": 2007,
+            "pickle_receiver_port": 2008,
+            "cache_query_port": 7004,
+            "line_receiver_interface": 0.0.0.0,
+            "udp_receiver_interface": 0.0.0.0,
+            "pickle_receiver_interface": 0.0.0.0,
+            "cache_query_interface": 0.0.0.0
+          }
+        }
+      }
+    }
+  }

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ group :test do
   gem 'kitchen-vagrant'
   gem 'kitchen-docker'
   gem 'librarian-chef'
+  gem 'rspec'
+  gem 'chefspec'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,15 @@
+#
+# A function which assists in carbon-cache service discover
+#
+def find_carbon_cache_services(node)
+  caches = []
+  case node['graphite']['carbon']['service_type']
+  when 'runit'
+    node['graphite']['carbon']['caches'].each do |instance, data|
+      caches << "runit_service[carbon-cache-#{instance}]"
+    end
+  else
+    caches << "service[carbon-cache]"
+  end
+  caches
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,7 @@
+# Matchers for chefspec 3
+
+if defined?(ChefSpec)
+  def enable_runit_service(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:runit_service, :enable, resource_name)
+  end
+end

--- a/recipes/carbon_cache.rb
+++ b/recipes/carbon_cache.rb
@@ -16,14 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 service_type = node['graphite']['carbon']['service_type']
-case service_type
-when 'runit'
-  carbon_cache_service_resource = 'runit_service[carbon-cache]'
-else
-  carbon_cache_service_resource = 'service[carbon-cache]'
-end
+caches = find_carbon_cache_services(node)
 
 template "#{node['graphite']['base_dir']}/conf/storage-schemas.conf" do
   source 'storage.conf.erb'
@@ -31,7 +25,9 @@ template "#{node['graphite']['base_dir']}/conf/storage-schemas.conf" do
   group node['graphite']['group_account']
   variables(:storage_config => node['graphite']['storage_schemas'])
   only_if { node['graphite']['storage_schemas'].is_a?(Array) }
-  notifies :restart, carbon_cache_service_resource
+  caches.each do |service|
+    notifies :restart, service
+  end
 end
 
 if node['graphite']['storage_aggregation'].is_a?(Array) && node['graphite']['storage_aggregation'].length > 0
@@ -40,12 +36,16 @@ if node['graphite']['storage_aggregation'].is_a?(Array) && node['graphite']['sto
     owner node['graphite']['user_account']
     group node['graphite']['group_account']
     variables(:storage_config => node['graphite']['storage_aggregation'])
-    notifies :restart, carbon_cache_service_resource
+    caches.each do |service|
+      notifies :restart, service
+    end
   end
 else
   file "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf" do
     action :delete
-    notifies :restart, carbon_cache_service_resource
+    caches.each do |service|
+      notifies :restart, service
+    end
   end
 end
 

--- a/recipes/carbon_cache_runit.rb
+++ b/recipes/carbon_cache_runit.rb
@@ -19,11 +19,13 @@
 
 include_recipe 'runit'
 
-runit_service 'carbon-cache' do
-  run_template_name 'carbon'
-  log_template_name 'carbon'
-  finish_script_template_name 'carbon'
-  finish true
-  options(:name => 'cache')
-  subscribes :restart, "template[#{node['graphite']['base_dir']}/conf/carbon.conf]"
+node['graphite']['carbon']['caches'].each do |key,data|
+  runit_service "carbon-cache-#{key}" do
+    run_template_name 'carbon'
+    log_template_name 'carbon'
+    finish_script_template_name 'carbon'
+    finish true
+    options(:name => "cache", :instance => key)
+    subscribes :restart, "template[#{node['graphite']['base_dir']}/conf/carbon.conf]"
+  end
 end

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../../libraries/helpers'
+
+describe 'find_carbon_cache_services' do
+  let(:node) do
+    Hash[
+      'graphite' => {
+        'carbon' => {
+          'service_type' => 'runit',
+          'caches' => {
+            'a' => { 'line_reciever_port' => 2003 },
+            'b' => { 'line_reciever_port' => 2004 },
+            'c' => { 'line_receiver_port' => 2005 }
+          }
+        }
+      }
+    ]
+  end
+
+  context 'when a single carbon-cache service is defined and run under runit' do
+    before do
+      node['graphite']['carbon']['caches'].delete('b')
+      node['graphite']['carbon']['caches'].delete('c')
+    end
+
+    it 'should return a single runit_service carbon-cache service name' do
+      caches = find_carbon_cache_services(node)
+      caches.should == [
+        'runit_service[carbon-cache-a]',
+      ]
+    end
+  end
+
+  context 'when multiple carbon-cache services are defined and run under runit' do
+    it 'should return multiple runit_service carbon-cache service names' do
+      caches = find_carbon_cache_services(node)
+      caches.sort.should == [
+        'runit_service[carbon-cache-a]',
+        'runit_service[carbon-cache-b]',
+        'runit_service[carbon-cache-c]'
+      ]
+    end
+  end
+
+
+  context 'when a single carbon-cache service is defined and not run under runit' do
+    before do
+      node['graphite']['carbon']['service_type'] = ""
+      node['graphite']['carbon']['caches'].delete('b')
+      node['graphite']['carbon']['caches'].delete('c')
+    end
+
+    it 'should return a single service carbon-cache service name' do
+      caches = find_carbon_cache_services(node)
+      caches.sort.should == ['service[carbon-cache]']
+    end
+  end
+
+  context 'when multiple carbon-cache services are defined and not run under runit' do
+    before do
+      node['graphite']['carbon']['service_type'] = ""
+    end
+
+    it 'should return a single service carbon-cache service name' do
+      caches = find_carbon_cache_services(node)
+      caches.sort.should == ['service[carbon-cache]']
+    end
+  end
+end

--- a/spec/unit/recipes/carbon_cache_runit_spec.rb
+++ b/spec/unit/recipes/carbon_cache_runit_spec.rb
@@ -1,0 +1,35 @@
+require 'chefspec'
+require 'chefspec/librarian'
+
+describe 'graphite::carbon_cache_runit' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.set['graphite']['carbon']['caches']['a']['line_receiver_port'] = 2003
+      node.set['graphite']['carbon']['caches']['a']['udp_receiver_port'] = 2003
+      node.set['graphite']['carbon']['caches']['a']['pickle_receiver_port'] = 2004
+      node.set['graphite']['carbon']['caches']['a']['cache_query_port'] = 7002
+      node.set['graphite']['carbon']['caches']['b']['line_receiver_port'] = 2005
+      node.set['graphite']['carbon']['caches']['b']['udp_receiver_port'] = 2005
+      node.set['graphite']['carbon']['caches']['b']['pickle_receiver_port'] = 2006
+      node.set['graphite']['carbon']['caches']['b']['cache_query_port'] = 7003
+      node.set['graphite']['carbon']['caches']['c']['line_receiver_port'] = 2007
+      node.set['graphite']['carbon']['caches']['c']['udp_receiver_port'] = 2007
+      node.set['graphite']['carbon']['caches']['c']['pickle_receiver_port'] = 2008
+      node.set['graphite']['carbon']['caches']['c']['cache_query_port'] = 7004
+
+      # Work around for lack of platform defaults in runit
+      node.set['runit']['sv_bin'] = '/usr/bin/sv'
+    end.converge(described_recipe)
+  end
+
+  it 'should include the runit cookbook' do
+    expect(chef_run).to include_recipe('runit')
+  end
+
+  it 'should define 3 runit services named after each carbon cache' do
+    expect(chef_run).to enable_runit_service('carbon-cache-a')
+    expect(chef_run).to enable_runit_service('carbon-cache-b')
+    expect(chef_run).to enable_runit_service('carbon-cache-c')
+  end
+end
+

--- a/spec/unit/recipes/carbon_cache_spec.rb
+++ b/spec/unit/recipes/carbon_cache_spec.rb
@@ -1,0 +1,74 @@
+require 'chefspec'
+require 'chefspec/librarian'
+
+describe 'graphite::carbon_cache' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.set['graphite']['carbon']['service_type'] = 'runit'
+      node.set['graphite']['base_dir'] = '/opt/graphite'
+      node.set['graphite']['carbon']['caches']['a']['line_receiver_port'] = 2003
+      node.set['graphite']['carbon']['caches']['a']['udp_receiver_port'] = 2003
+      node.set['graphite']['carbon']['caches']['a']['pickle_receiver_port'] = 2004
+      node.set['graphite']['carbon']['caches']['a']['cache_query_port'] = 7002
+      node.set['graphite']['carbon']['caches']['b']['line_receiver_port'] = 2005
+      node.set['graphite']['carbon']['caches']['b']['udp_receiver_port'] = 2005
+      node.set['graphite']['carbon']['caches']['b']['pickle_receiver_port'] = 2006
+      node.set['graphite']['carbon']['caches']['b']['cache_query_port'] = 7003
+      node.set['graphite']['carbon']['caches']['c']['line_receiver_port'] = 2007
+      node.set['graphite']['carbon']['caches']['c']['udp_receiver_port'] = 2007
+      node.set['graphite']['carbon']['caches']['c']['pickle_receiver_port'] = 2008
+      node.set['graphite']['carbon']['caches']['c']['cache_query_port'] = 7004
+
+      # Work around for lack of platform defaults in runit
+      node.set['runit']['sv_bin'] = '/usr/bin/sv'
+    end.converge(described_recipe)
+  end
+
+  it 'should create the storage-schemas.conf file and restart each carbon-cache runit daemons' do
+    expect(chef_run).to create_template('/opt/graphite/conf/storage-schemas.conf')
+
+    resource = chef_run.template('/opt/graphite/conf/storage-schemas.conf')
+    expect(resource).to notify('runit_service[carbon-cache-a]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-b]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-c]').to(:restart)
+  end
+
+  it 'should delete the default storage-aggregation.conf file and restart each carbon-cache runit daemon' do
+    expect(chef_run).to delete_file('/opt/graphite/conf/storage-aggregation.conf')
+
+    resource = chef_run.file('/opt/graphite/conf/storage-aggregation.conf')
+    expect(resource).to notify('runit_service[carbon-cache-a]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-b]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-c]').to(:restart)
+  end
+
+  it 'should create the storage-aggregation.conf file and restart each carbon-cache runit daemon' do
+    chef_run.node.set['graphite']['storage_aggregation'] = [
+      {
+        'name' => 'all_min',
+        'pattern' => '\.min$',
+        'xFilesFactor' => '0.1',
+        'aggregationMethod' => 'min'
+      },
+      {
+        'name' => 'count',
+        'pattern' => '\.count$',
+        'xFilesFactor' => '0',
+        'aggregationMethod' => 'sum'
+      },
+    ]
+    chef_run.converge(described_recipe)
+
+    expect(chef_run).to create_template('/opt/graphite/conf/storage-aggregation.conf')
+
+    resource = chef_run.template('/opt/graphite/conf/storage-aggregation.conf')
+    expect(resource).to notify('runit_service[carbon-cache-a]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-b]').to(:restart)
+    expect(resource).to notify('runit_service[carbon-cache-c]').to(:restart)
+  end
+
+  it 'should include the graphite carbon cache runit recipe' do
+    expect(chef_run).to include_recipe('graphite::carbon_cache_runit')
+  end
+end
+

--- a/templates/default/sv-carbon-finish.erb
+++ b/templates/default/sv-carbon-finish.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
-PIDFILE="<%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %>-a.pid"
+PIDFILE="<%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %><%= @options[:instance] %>.pid"
 
 if [ -e $PIDFILE ]; then
     rm -v $PIDFILE

--- a/templates/default/sv-carbon-run.erb
+++ b/templates/default/sv-carbon-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= node['graphite']['user_account'] %> -l <%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %>.lock -- <%= node['graphite']['base_dir']%>/bin/carbon-<%= @options[:name] %>.py --pid <%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %>-a.pid --debug start
+exec chpst -u <%= node['graphite']['user_account'] %> -l <%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %><%= @options[:instance] %>.lock -- <%= node['graphite']['base_dir']%>/bin/carbon-<%= @options[:name] %>.py --pid <%= node['graphite']['storage_dir'] %>/carbon-<%= @options[:name] %>-<%= @options[:instance] %>.pid --instance=<%= @options[:instance] %> --debug start

--- a/test/integration/carbon-cache/bats/carbon-cache.bats
+++ b/test/integration/carbon-cache/bats/carbon-cache.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+@test "carbon-cache-a should be running" {
+  ps aux | grep carbon-cache-a.pid
+}
+
+@test "carbon-cache-b should be running" {
+  ps aux | grep carbon-cache-b.pid
+}
+
+@test "carbon-cache-c should be running" {
+  ps aux | grep carbon-cache-c.pid
+}
+
+@test "carbon-cache-a should be listening on port 2003" {
+  pid="$(ps aux | grep carbon-cache-a.pid | awk '{print $2}' | head -1)"
+  lsof -Pna -itcp:2003 -sTCP:LISTEN -p$pid 2> /dev/null
+}
+
+@test "carbon-cache-b should be listening on port 2005" {
+  pid="$(ps aux | grep carbon-cache-b.pid | awk '{print $2}' | head -1)"
+  lsof -Pna -itcp:2005 -sTCP:LISTEN -p$pid 2> /dev/null
+}
+
+@test "carbon-cache-c should be listening on port 2007" {
+  pid="$(ps aux | grep carbon-cache-c.pid | awk '{print $2}' | head -1)"
+  lsof -Pna -itcp:2007 -sTCP:LISTEN -p$pid 2> /dev/null
+}
+


### PR DESCRIPTION
This allows runit to manage multiple carbon-cache daemons. I have included tests with this pull request to make it easier to verify. 

It looks like some of the integration tests on master don't actually work. I could not get the CentOS-64 and Ubuntu 10.04 tests to work at all. I tested against the default-ubuntu-1204 and the carbon-cache-ubuntu-1204 tests. I did not clean up the other tests here because I did not want to muddy this pull request. 

I would love some feedback and a code review if someone has time.
