### PR TITLE
Allow to setup carbon connection for uwsgi

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -1,4 +1,4 @@
 default['graphite']['uwsgi']['socket'] = '/tmp/uwsgi.sock'
 default['graphite']['uwsgi']['workers'] = 8
-default['graphite']['uwsgi']['carbon'] = true
+default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
 default['graphite']['uwsgi']['listen_http'] = true

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -2,7 +2,7 @@
 exec 2>&1
 exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
 <% if node['graphite']['uwsgi']['carbon'] -%>
---plugins carbon --carbon 127.0.0.1:2003 \
+--plugins carbon --carbon <%= node['graphite']['uwsgi']['carbon'] %> \
 <% end -%>
 <% if node['graphite']['uwsgi']['listen_http'] -%>
 --http :<%= node['graphite']['listen_port'] %> \


### PR DESCRIPTION
Hi,

I need to change the carbon plugin connection IP for the uwsgi, so I change the default attribute to string instead of boolean. So you can change the IP from attibutes and if you don't want to use carbon, just set it to `false`
