### PR TITLE
Changed package name for CentOS to Django14

### DIFF
--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -48,7 +48,12 @@ dep_packages = case node['platform_family']
 
                  packages
                when 'rhel', 'fedora'
-                 packages = %w{ Django django-tagging pycairo-devel python-devel mod_wsgi python-sqlite2 python-zope-interface }
+                 case node['platform']
+                 when 'centos'
+                   packages = %w{ Django14 django-tagging pycairo-devel python-devel mod_wsgi python-sqlite2 python-zope-interface }
+                 else
+                   packages = %w{ Django django-tagging pycairo-devel python-devel mod_wsgi python-sqlite2 python-zope-interface }
+                 end
 
                  # Include bitmap packages (optionally)
                  if node['graphite']['web']['bitmap_support']


### PR DESCRIPTION
Not sure if this is a rhel-wide thing (I think it might be cuz the change seems to be in epel), but the package name Django changed to Django14. If someone confirms this is rhel/fedora wide, then you should probably reject this in favor of just changing the package name for all rhel/fedora.
