### PR TITLE
Fix compatibility issue with chef version on AWS

### DIFF
--- a/libraries/lazy_helper.rb
+++ b/libraries/lazy_helper.rb
@@ -1,0 +1,4 @@
+def external_lazy_needed?(node)
+  Gem::Version.new(node['chef_packages']['chef']['version'])
+                     .between?(Gem::Version.new('11.0.0'), Gem::Version.new('11.6.0'))
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,7 @@ depends  'python'
 depends  'apache2'
 depends  'runit', '~> 1.0'
 depends  'memcached'
+depends  'delayed_evaluator'
 
 suggests 'systemd'
 suggests 'graphiti'
-suggests 'delayed_evaluator'

--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+if external_lazy_needed?(node)
+  include_recipe 'delayed_evaluator'
+end
+
 package 'python-twisted'
 package 'python-simplejson'
 

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+if external_lazy_needed?(node)
+  include_recipe 'delayed_evaluator'
+end
 
 basedir = node['graphite']['base_dir']
 docroot = node['graphite']['doc_root']

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+if external_lazy_needed?(node)
+  include_recipe 'delayed_evaluator'
+end
 
 python_pip 'whisper' do
   package_name lazy {


### PR DESCRIPTION
On Amazon there's only 0.9 (supported till july 2014) and 11.4 which don't have 'lazy'
