### PR TITLE
Add option to disable django caching

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,7 @@ default['graphite']['package_names'] = {
 #
 # graphite_web
 #
+default['graphite']['web']['django_cache'] = true
 default['graphite']['web']['debug'] = 'False'
 default['graphite']['web']['bitmap_support'] = true
 default['graphite']['web']['admin_email'] = 'admin@org.com'

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -74,6 +74,7 @@ template "#{docroot}/graphite/local_settings.py" do
   mode 00755
   variables(:timezone => node['graphite']['timezone'],
             :debug => node['graphite']['web']['debug'],
+	    :django_cache => node['graphite']['web']['django_cache'],
             :base_dir => node['graphite']['base_dir'],
             :doc_root => node['graphite']['doc_root'],
             :storage_dir => node['graphite']['storage_dir'],

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -226,3 +226,10 @@ end.join(', ') %> ]
 # MIDDLEWARE_CLASSES or APPS
 #from graphite.app_settings import *
 
+<% unless @django_cache %>
+CACHES = {
+  'default': {
+    'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+  },
+}    
+<% end %>


### PR DESCRIPTION
This will allow the rest api to return up-to-date metrics at a resolution lower than one minute.
