### PR TITLE
updating and adding support for multiple carbon_relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ carbon-relay.py attributes
 --------------------------
 
 * `node['graphite']['relay_rules']` - an array with relay rules for sending metrics to a certain backends, used to generate the *relay-rules.conf* file ([see the example below](#relay_rules-example))
-* `node['graphite']['carbon']['relay']['line_receiver_interface']` - line interface IP (defaults to 0.0.0.0)
-* `node['graphite']['carbon']['relay']['line_receiver_port']` - line interface port (defaults to 2013)
-* `node['graphite']['carbon']['relay']['pickle_receiver_interface']` - pickle receiver IP (defaults to 0.0.0.0)
-* `node['graphite']['carbon']['relay']['pickle_receiver_port']` - pickle receiver port (defaults to 2014)
-* `node['graphite']['carbon']['relay']['relay_method']` - choose between *consistent-hashing* and *rules* (defaults to "rules")
-* `node['graphite']['carbon']['relay']['replication_factor']` - used to replicate datapoint data to more than one machine (defaults to 1)
+* `node['graphite']['carbon']['relays']['a']['line_receiver_interface']` - line interface IP (defaults to 0.0.0.0)
+* `node['graphite']['carbon']['relays']['a']['line_receiver_port']` - line interface port (defaults to 2013)
+* `node['graphite']['carbon']['relays']['a']['pickle_receiver_interface']` - pickle receiver IP (defaults to 0.0.0.0)
+* `node['graphite']['carbon']['relays']['a']['pickle_receiver_port']` - pickle receiver port (defaults to 2014)
+* `node['graphite']['carbon']['relays']['a']['relay_method']` - choose between *consistent-hashing* and *rules* (defaults to "rules")
+* `node['graphite']['carbon']['relays']['a']['replication_factor']` - used to replicate datapoint data to more than one machine (defaults to 1)
 * `node['graphite']['carbon']['relay']['destinations']` - list of carbon daemons to send metrics to
 * `node['graphite']['carbon']['relay']['max_datapoints_per_message']` - maximum datapoints to send in a message between carbon daemons (defaults to 500)
 * `node['graphite']['carbon']['relay']['max_queue_size']` - maximum queue of messages used to comunicate to other carbon daemons (defaults to 10000)

--- a/attributes/carbon_cache.rb
+++ b/attributes/carbon_cache.rb
@@ -19,6 +19,11 @@ default['graphite']['carbon']['max_creates_per_minute'] = 'inf'
 default['graphite']['carbon']['max_updates_per_second'] = '1000'
 default['graphite']['carbon']['log_whisper_updates'] = 'False'
 default['graphite']['carbon']['whisper_autoflush'] = 'False'
+default['graphite']['carbon']['log_cache_queue_sorts'] = 'True'
+default['graphite']['carbon']['log_updates'] = 'False'
+default['graphite']['carbon']['log_listener_connections'] = 'True'
+default['graphite']['carbon']['log_cache_hits'] = 'False'
+default['graphite']['carbon']['whisper_fallocate_create'] = 'True'
 
 default['graphite']['storage_schemas'] = [
   {

--- a/attributes/carbon_relay.rb
+++ b/attributes/carbon_relay.rb
@@ -5,15 +5,16 @@
 
 default['graphite']['relay_rules'] = []
 
-default['graphite']['carbon']['relay']['line_receiver_interface'] = '0.0.0.0'
-default['graphite']['carbon']['relay']['line_receiver_port'] = 2013
-default['graphite']['carbon']['relay']['pickle_receiver_interface'] = '0.0.0.0'
-default['graphite']['carbon']['relay']['pickle_receiver_port'] = 2014
-default['graphite']['carbon']['relay']['udp_receiver_interface'] = '0.0.0.0'
-default['graphite']['carbon']['relay']['udp_receiver_port'] = 2013
-default['graphite']['carbon']['relay']['method'] = 'rules' # rules | consistent-hashing
-default['graphite']['carbon']['relay']['replication_factor'] = 1
+default['graphite']['carbon']['relays']['a']['line_receiver_interface'] = '0.0.0.0'
+default['graphite']['carbon']['relays']['a']['line_receiver_port'] = 2013
+default['graphite']['carbon']['relays']['a']['pickle_receiver_interface'] = '0.0.0.0'
+default['graphite']['carbon']['relays']['a']['pickle_receiver_port'] = 2014
+default['graphite']['carbon']['relays']['a']['udp_receiver_interface'] = '0.0.0.0'
+default['graphite']['carbon']['relays']['a']['udp_receiver_port'] = 2013
+default['graphite']['carbon']['relays']['a']['method'] = 'rules' # rules | consistent-hashing
+default['graphite']['carbon']['relays']['a']['replication_factor'] = 1
 default['graphite']['carbon']['relay']['destinations'] = []
+default['graphite']['carbon']['relay']['replication_relay'] = []
 default['graphite']['carbon']['relay']['max_datapoints_per_message'] = 500
 default['graphite']['carbon']['relay']['max_queue_size'] = 10000
 default['graphite']['carbon']['relay']['use_flow_control'] = 'True'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,3 +13,16 @@ def find_carbon_cache_services(node)
   end
   caches
 end
+
+def find_carbon_relay_services(node)
+  relay = []
+  case node['graphite']['carbon']['service_type']
+    when 'runit'
+      node['graphite']['carbon']['relay'].each do |instance, data|
+        relays << "runit_service[carbon-relay-#{instance}]"
+      end
+    else
+      relay << "service[carbon-relay]"
+    end
+    relay
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@hw-ops.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.8'
+version          '0.4.46'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/carbon_relay_init.rb
+++ b/recipes/carbon_relay_init.rb
@@ -28,7 +28,7 @@ template '/etc/init.d/carbon-relay' do
     :name       => 'relay',
     :dir        => node['graphite']['base_dir'],
     :user       => node['graphite']['user_account'],
-    :instances  => { 'a' => '' }
+    :instances  => node['graphite']['carbon']['relays']
   )
   mode 00744
   notifies :restart, 'service[carbon-relay]'

--- a/recipes/carbon_relay_upstart.rb
+++ b/recipes/carbon_relay_upstart.rb
@@ -23,7 +23,7 @@ template '/etc/init/carbon-relay.conf' do
     :name       => 'relay',
     :dir        => node['graphite']['base_dir'],
     :user       => node['graphite']['user_account'],
-    :instances  => { 'a' => '' }
+    :instances  => node['graphite']['carbon']['relays']
   )
   mode 00644
 end

--- a/spec/unit/recipes/carbon_cache_runit_spec.rb
+++ b/spec/unit/recipes/carbon_cache_runit_spec.rb
@@ -12,10 +12,6 @@ describe 'graphite::carbon_cache_runit' do
       node.set['graphite']['carbon']['caches']['b']['udp_receiver_port'] = 2005
       node.set['graphite']['carbon']['caches']['b']['pickle_receiver_port'] = 2006
       node.set['graphite']['carbon']['caches']['b']['cache_query_port'] = 7003
-      node.set['graphite']['carbon']['caches']['c']['line_receiver_port'] = 2007
-      node.set['graphite']['carbon']['caches']['c']['udp_receiver_port'] = 2007
-      node.set['graphite']['carbon']['caches']['c']['pickle_receiver_port'] = 2008
-      node.set['graphite']['carbon']['caches']['c']['cache_query_port'] = 7004
 
       # Work around for lack of platform defaults in runit
       node.set['runit']['sv_bin'] = '/usr/bin/sv'
@@ -29,7 +25,6 @@ describe 'graphite::carbon_cache_runit' do
   it 'should define 3 runit services named after each carbon cache' do
     expect(chef_run).to enable_runit_service('carbon-cache-a')
     expect(chef_run).to enable_runit_service('carbon-cache-b')
-    expect(chef_run).to enable_runit_service('carbon-cache-c')
   end
 end
 

--- a/spec/unit/recipes/carbon_cache_spec.rb
+++ b/spec/unit/recipes/carbon_cache_spec.rb
@@ -14,10 +14,6 @@ describe 'graphite::carbon_cache' do
       node.set['graphite']['carbon']['caches']['b']['udp_receiver_port'] = 2005
       node.set['graphite']['carbon']['caches']['b']['pickle_receiver_port'] = 2006
       node.set['graphite']['carbon']['caches']['b']['cache_query_port'] = 7003
-      node.set['graphite']['carbon']['caches']['c']['line_receiver_port'] = 2007
-      node.set['graphite']['carbon']['caches']['c']['udp_receiver_port'] = 2007
-      node.set['graphite']['carbon']['caches']['c']['pickle_receiver_port'] = 2008
-      node.set['graphite']['carbon']['caches']['c']['cache_query_port'] = 7004
 
       # Work around for lack of platform defaults in runit
       node.set['runit']['sv_bin'] = '/usr/bin/sv'
@@ -30,7 +26,6 @@ describe 'graphite::carbon_cache' do
     resource = chef_run.template('/opt/graphite/conf/storage-schemas.conf')
     expect(resource).to notify('runit_service[carbon-cache-a]').to(:restart)
     expect(resource).to notify('runit_service[carbon-cache-b]').to(:restart)
-    expect(resource).to notify('runit_service[carbon-cache-c]').to(:restart)
   end
 
   it 'should delete the default storage-aggregation.conf file and restart each carbon-cache runit daemon' do
@@ -64,7 +59,6 @@ describe 'graphite::carbon_cache' do
     resource = chef_run.template('/opt/graphite/conf/storage-aggregation.conf')
     expect(resource).to notify('runit_service[carbon-cache-a]').to(:restart)
     expect(resource).to notify('runit_service[carbon-cache-b]').to(:restart)
-    expect(resource).to notify('runit_service[carbon-cache-c]').to(:restart)
   end
 
   it 'should include the graphite carbon cache runit recipe' do

--- a/templates/default/carbon.conf.erb
+++ b/templates/default/carbon.conf.erb
@@ -1,132 +1,29 @@
-[cache]
-# Configure carbon directories.
-#
-# OS environment variables can be used to tell carbon where graphite is
-# installed, where to read configuration from and where to write data.
-#
-#   GRAPHITE_ROOT        - Root directory of the graphite installation.
-#                          Defaults to ../
-#   GRAPHITE_CONF_DIR    - Configuration directory (where this file lives).
-#                          Defaults to $GRAPHITE_ROOT/conf/
-#   GRAPHITE_STORAGE_DIR - Storage directory for whipser/rrd/log/pid files.
-#                          Defaults to $GRAPHITE_ROOT/storage/
-#
-# To change other directory paths, add settings to this file. The following
-# configuration variables are available with these default values:
-#
-#   STORAGE_DIR    = $GRAPHITE_STORAGE_DIR
-#   LOCAL_DATA_DIR = STORAGE_DIR/whisper/
-#   WHITELISTS_DIR = STORAGE_DIR/lists/
-#   CONF_DIR       = STORAGE_DIR/conf/
-#   LOG_DIR        = STORAGE_DIR/log/
-#   PID_DIR        = STORAGE_DIR/
-#
-# For FHS style directory structures, use:
-#
-#   STORAGE_DIR    = /var/lib/carbon/
-#   CONF_DIR       = /etc/carbon/
-#   LOG_DIR        = /var/log/carbon/
-#   PID_DIR        = /var/run/
-#
+[cache:a]
 LOCAL_DATA_DIR = <%= @storage_dir %>/whisper/
-
-# Specify the user to drop privileges to
-# If this is blank carbon runs as the user that invokes it
-# This user must have write access to the local data directory
 USER =
-
-# Limit the size of the cache to avoid swapping or becoming CPU bound.
-# Sorts and serving cache queries gets more expensive as the cache grows.
-# Use the value "inf" (infinity) for an unlimited cache size.
 MAX_CACHE_SIZE = <%= @carbon_options[:max_cache_size] %>
-
-# Limits the number of whisper update_many() calls per second, which effectively
-# means the number of write requests sent to the disk. This is intended to
-# prevent over-utilizing the disk and thus starving the rest of the system.
-# When the rate of required updates exceeds this, then carbon's caching will
-# take effect and increase the overall throughput accordingly.
 MAX_UPDATES_PER_SECOND = <%= @carbon_options[:max_updates_per_second] %>
-
-# Softly limits the number of whisper files that get created each minute.
-# Setting this value low (like at 50) is a good way to ensure your graphite
-# system will not be adversely impacted when a bunch of new metrics are
-# sent to it. The trade off is that it will take much longer for those metrics'
-# database files to all get created and thus longer until the data becomes usable.
-# Setting this value high (like "inf" for infinity) will cause graphite to create
-# the files quickly but at the risk of slowing I/O down considerably for a while.
 MAX_CREATES_PER_MINUTE = <%= @carbon_options[:max_creates_per_minute] %>
-
 LINE_RECEIVER_INTERFACE = <%= @carbon_options[:caches][:a][:line_receiver_interface] %>
 LINE_RECEIVER_PORT = <%= @carbon_options[:caches][:a][:line_receiver_port] %>
-
-# Set this to True to enable the UDP listener. By default this is off
-# because it is very common to run multiple carbon daemons and managing
-# another (rarely used) port for every carbon instance is not fun.
 ENABLE_UDP_LISTENER = <%= @carbon_options[:enable_udp_listener] %>
 UDP_RECEIVER_INTERFACE = <%= @carbon_options[:caches][:a][:udp_receiver_interface] %>
 UDP_RECEIVER_PORT = <%= @carbon_options[:caches][:a][:udp_receiver_port] %>
-
-PICKLE_RECEIVER_INTERFACE = <%= @carbon_options[:caches][:a][:pickle_receiver_interface] %>
 PICKLE_RECEIVER_PORT = <%= @carbon_options[:caches][:a][:pickle_receiver_port] %>
-
-# Per security concerns outlined in Bug #817247 the pickle receiver
-# will use a more secure and slightly less efficient unpickler.
-# Set this to True to revert to the old-fashioned insecure unpickler.
 USE_INSECURE_UNPICKLER = <%= @carbon_options[:use_insecure_unpickler] %>
-
-CACHE_QUERY_INTERFACE = <%= @carbon_options[:caches][:a][:cache_query_interface] %>
 CACHE_QUERY_PORT = <%= @carbon_options[:caches][:a][:cache_query_port] %>
-
-# Set this to False to drop datapoints received after the cache
-# reaches MAX_CACHE_SIZE. If this is True (the default) then sockets
-# over which metrics are received will temporarily stop accepting
-# data until the cache size falls below 95% MAX_CACHE_SIZE.
 USE_FLOW_CONTROL = <%= @carbon_options[:use_flow_control] %>
-
-# By default, carbon-cache will log every whisper update. This can be excessive and
-# degrade performance if logging on the same volume as the whisper data is stored.
 LOG_UPDATES = <%= @carbon_options[:log_whisper_updates] %>
-
-# On some systems it is desirable for whisper to write synchronously.
-# Set this option to True if you'd like to try this. Basically it will
-# shift the onus of buffering writes from the kernel into carbon's cache.
 WHISPER_AUTOFLUSH = <%= @carbon_options[:whisper_autoflush] %>
-
-# By default new Whisper files are created pre-allocated with the data region
-# filled with zeros to prevent fragmentation and speed up contiguous reads and
-# writes (which are common). Enabling this option will cause Whisper to create
-# the file sparsely instead. Enabling this option may allow a large increase of
-# MAX_CREATES_PER_MINUTE but may have longer term performance implications
-# depending on the underlying storage configuration.
-# WHISPER_SPARSE_CREATE = False
-
-# Enabling this option will cause Whisper to lock each Whisper file it writes
-# to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when
-# multiple carbon-cache daemons are writing to the same files
-# WHISPER_LOCK_WRITES = False
-
-# Set this to True to enable whitelisting and blacklisting of metrics in
-# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
-# empty, all metrics will pass through
-# USE_WHITELIST = False
-
-# By default, carbon itself will log statistics (such as a count,
-# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
-# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
-# CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
-
-# Enable AMQP if you want to receve metrics using an amqp broker
+LOG_CACHE_QUEUE_SORTS = <%= @carbon_options[:log_cache_queue_sorts] %>
+LOG_UPDATES = <%= @carbon_options[:log_updates] %>
+LOG_LISTENER_CONNECTIONS = <%= @carbon_options[:log_listener_connections] %>
+LOG_CACHE_HITS = <%= @carbon_options[:log_cache_hits] %>
+WHISPER_FALLOCATE_CREATE = <%= @carbon_options[:whisper_fallocate_create] %>
 <% if @carbon_options[:enable_amqp] %>
 ENABLE_AMQP = True
 <% else %>
-# ENABLE_AMQP = False
 <% end %>
-
-# Verbose means a line will be logged for every metric received
-# useful for testing
-# AMQP_VERBOSE = False
-
 <% if @carbon_options[:enable_amqp] %>
 AMQP_HOST = <%= @carbon_options[:amqp_host] %>
 AMQP_PORT = <%= @carbon_options[:amqp_port] %>
@@ -136,36 +33,7 @@ AMQP_PASSWORD = <%= @carbon_options[:amqp_password] %>
 AMQP_EXCHANGE = <%= @carbon_options[:amqp_exchange] %>
 AMQP_METRIC_NAME_IN_BODY = <%= @carbon_options[:amqp_metric_name_in_body] ? "True" : "False" %>
 <% else %>
-# AMQP_HOST = localhost
-# AMQP_PORT = 5672
-# AMQP_VHOST = /
-# AMQP_USER = guest
-# AMQP_PASSWORD = guest
-# AMQP_EXCHANGE = graphite
-# AMQP_METRIC_NAME_IN_BODY = False
 <% end %>
-
-# The manhole interface allows you to SSH into the carbon daemon
-# and get a python interpreter. BE CAREFUL WITH THIS! If you do
-# something like time.sleep() in the interpreter, the whole process
-# will sleep! This is *extremely* helpful in debugging, assuming
-# you are familiar with the code. If you are not, please don't
-# mess with this, you are asking for trouble :)
-#
-# ENABLE_MANHOLE = False
-# MANHOLE_INTERFACE = 127.0.0.1
-# MANHOLE_PORT = 7222
-# MANHOLE_USER = admin
-# MANHOLE_PUBLIC_KEY = ssh-rsa AAAAB3NzaC1yc2EAAAABiwAaAIEAoxN0sv/e4eZCPpi3N3KYvyzRaBaMeS2RsOQ/cDuKv11dlNzVeiyc3RFmCv5Rjwn/lQ79y0zyHxw67qLyhQ/kDzINc4cY41ivuQXm2tPmgvexdrBv5nsfEpjs3gLZfJnyvlcVyWK/lId8WUvEWSWHTzsbtmXAF2raJMdgLTbQ8wE=
-
-# Patterns for all of the metrics this machine will store. Read more at
-# http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Bindings
-#
-# Example: store all sales, linux servers, and utilization metrics
-# BIND_PATTERNS = sales.#, servers.linux.#, #.utilization
-#
-# Example: store everything
-# BIND_PATTERNS = #
 
 <% if @carbon_options[:caches].length > 1 -%>
 # Configure special settings for other the carbon-cache instances
@@ -178,83 +46,60 @@ PICKLE_RECEIVER_INTERFACE = <%= instance.last[:pickle_receiver_interface] %>
 PICKLE_RECEIVER_PORT = <%= instance.last[:pickle_receiver_port] %>
 CACHE_QUERY_INTERFACE = <%= instance.last[:cache_query_interface] %>
 CACHE_QUERY_PORT = <%= instance.last[:cache_query_port] %>
-
+USE_FLOW_CONTROL = <%= @carbon_options[:use_flow_control] %>
+LOG_UPDATES = <%= @carbon_options[:log_whisper_updates] %>
+WHISPER_AUTOFLUSH = <%= @carbon_options[:whisper_autoflush] %>
+LOG_CACHE_QUEUE_SORTS = <%= @carbon_options[:log_cache_queue_sorts] %>
+LOG_UPDATES = <%= @carbon_options[:log_updates] %>
+LOG_LISTENER_CONNECTIONS = <%= @carbon_options[:log_listener_connections] %>
+LOG_CACHE_HITS = <%= @carbon_options[:log_cache_hits] %>
+WHISPER_FALLOCATE_CREATE = <%= @carbon_options[:whisper_fallocate_create] %>
 <%     end -%>
 <%   end -%>
 <% else -%>
-# To configure special settings for other the carbon-cache instance 'b', uncomment this:
-#[cache:b]
-#LINE_RECEIVER_PORT = 2103
-#PICKLE_RECEIVER_PORT = 2104
-#CACHE_QUERY_PORT = 7102
-# and any other settings you want to customize, defaults are inherited
-# from [carbon] section.
-# You can then specify the --instance=b option to manage this instance
 <% end -%>
 
-
-[relay]
-LINE_RECEIVER_INTERFACE = <%= @carbon_options[:relay][:line_receiver_interface] %>
-LINE_RECEIVER_PORT = <%= @carbon_options[:relay][:line_receiver_port] %>
-PICKLE_RECEIVER_INTERFACE = <%= @carbon_options[:relay][:pickle_receiver_interface] %>
-PICKLE_RECEIVER_PORT = <%= @carbon_options[:relay][:pickle_receiver_port] %>
-UDP_RECEIVER_INTERFACE = <%= @carbon_options[:relay][:udp_receiver_interface] %>
-UDP_RECEIVER_PORT = <%= @carbon_options[:relay][:udp_receiver_port] %>
-
-# To use consistent hashing instead of the user defined relay-rules.conf,
-# change this to:
-# RELAY_METHOD = consistent-hashing
-RELAY_METHOD = <%= @carbon_options[:relay][:method] %>
-
-# If you use consistent-hashing you may want to add redundancy
-# of your data by replicating every datapoint to more than
-# one machine.
-REPLICATION_FACTOR = <%= @carbon_options[:relay][:replication_factor] %>
-
-# This is a list of carbon daemons we will send any relayed or
-# generated metrics to. The default provided would send to a single
-# carbon-cache instance on the default port. However if you
-# use multiple carbon-cache instances then it would look like this:
-#
-# DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
-#
-# The general form is IP:PORT:INSTANCE where the :INSTANCE part is
-# optional and refers to the "None" instance if omitted.
-#
-# Note that if the destinations are all carbon-caches then this should
-# exactly match the webapp's CARBONLINK_HOSTS setting in terms of
-# instances listed (order matters!).
-#
-# If using RELAY_METHOD = rules, all destinations used in relay-rules.conf
-# must be defined in this list
-<% if @carbon_options[:relay][:destinations].length > 0 -%>
-DESTINATIONS = <%= @carbon_options[:relay][:destinations].join(', ') %>
+[relay:a]
+LINE_RECEIVER_INTERFACE = <%= @carbon_options[:relays][:a][:line_receiver_interface] %>
+LINE_RECEIVER_PORT = <%= @carbon_options[:relays][:a][:line_receiver_port] %>
+PICKLE_RECEIVER_INTERFACE = <%= @carbon_options[:relays][:a][:pickle_receiver_interface] %>
+PICKLE_RECEIVER_PORT = <%= @carbon_options[:relays][:a][:pickle_receiver_port] %>
+UDP_RECEIVER_INTERFACE = <%= @carbon_options[:relays][:a][:udp_receiver_interface] %>
+UDP_RECEIVER_PORT = <%= @carbon_options[:relays][:a][:udp_receiver_port] %>
+RELAY_METHOD = <%= @carbon_options[:relays][:a][:method] %>
+REPLICATION_FACTOR = <%= @carbon_options[:relays][:a][:replication_factor] %>
+<% if @carbon_options[:relay][:primary_relay].length > 0 -%>
+DESTINATIONS = <%= @carbon_options[:relay][:primary_relay].join(', ') %>
 <% else -%>
 DESTINATIONS = 127.0.0.1:2004
 <% end -%>
-
-# This defines the maximum "message size" between carbon daemons.
-# You shouldn't need to tune this unless you really know what you're doing.
 MAX_DATAPOINTS_PER_MESSAGE = <%= @carbon_options[:relay][:max_datapoints_per_message] %>
 MAX_QUEUE_SIZE = <%= @carbon_options[:relay][:max_queue_size] %>
-
-# Set this to False to drop datapoints when any send queue (sending datapoints
-# to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
-# default) then sockets over which metrics are received will temporarily stop accepting
-# data until the send queues fall below 80% MAX_QUEUE_SIZE.
 USE_FLOW_CONTROL = <%= @carbon_options[:relay][:use_flow_control] %>
 
-# Set this to True to enable whitelisting and blacklisting of metrics in
-# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
-# empty, all metrics will pass through
-# USE_WHITELIST = False
-
-# By default, carbon itself will log statistics (such as a count,
-# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
-# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
-# CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
-
+<% if @carbon_options[:relays].length > 1 -%>
+#configure additional relays
+<% @carbon_options[:relays].each do |instance| -%>
+<%  if instance.first != "a" -%>
+[relay:<%= instance.first %>]
+LINE_RECEIVER_INTERFACE = <%= instance.last[:line_receiver_interface] %>
+LINE_RECEIVER_PORT =  <%= instance.last[:line_receiver_port] %>
+PICKLE_RECEIVER_INTERFACE =  <%= instance.last[:pickle_receiver_interface] %>
+PICKLE_RECEIVER_PORT = <%= instance.last[:pickle_receiver_port] %>
+UDP_RECEIVER_INTERFACE = <%= instance.last[:udp_receiver_port] %>
+UDP_RECEIVER_PORT = <%= instance.last[:udp_receiver_port] %>
+<% if @carbon_options[:relay][:destinations].length > 0 -%>
+DESTINATIONS = <%= @carbon_options[:relay][:destinations].join(', ') %>
+<% end -%>
+RELAY_METHOD = <%= instance.last[:method] %>
+REPLICATION_FACTOR = <%= instance.last[:replication_factor] %>
+MAX_DATAPOINTS_PER_MESSAGE = <%= @carbon_options[:relay][:max_datapoints_per_message] %>
+MAX_QUEUE_SIZE = <%= @carbon_options[:relay][:max_queue_size] %>
+USE_FLOW_CONTROL = <%= @carbon_options[:relay][:use_flow_control] %>
+<% end -%>
+<% end -%>
+<% else -%>
+<% end -%>
 
 [aggregator]
 LINE_RECEIVER_INTERFACE = <%= @carbon_options[:aggregator][:line_receiver_interface] %>

--- a/templates/default/carbon.init.erb
+++ b/templates/default/carbon.init.erb
@@ -10,11 +10,11 @@
 export CC_HOME="<%= @dir %>"
 <% @instances.each do |instance| -%>
 export PIDFILE_<%= instance.first %>="$CC_HOME/storage/carbon-<%= @name %>-<%= instance.first %>.pid"
-<% end -%>
 export CC_CONFIG="$CC_HOME/etc/carbon-<%= @name %>.conf"
 CC_USER="<%= @user %>"
-LOGDIR="/var/log/carbon-<%= @name %>"
-CC_LOG="$LOGDIR/carbon-<%= @name %>.log"
+LOGDIR="/opt/graphite/storage/log/carbon-<%= @name %>/carbon-<%= @name %>-<%= instance.first %>"
+<% end -%>
+CC_LOG="$LOGDIR/console.log"
 <% @instances.each do |instance| -%>
 BIN_SCRIPT_<%= instance.first %>="python $CC_HOME/bin/carbon-<%= @name %>.py --instance=<%= instance.first %> start >> $CC_LOG 2>&1"
 <% end -%>


### PR DESCRIPTION
Hey guys.. This version basically adds the ability to setup multiple carbon_relays for your graphite cluster. I noticed this was missing and figured it would be a good thing to add. It also changes the the frontend from looking at the cache_query_port rather than the pickle port. 
