### PR TITLE
Update upstart config to honor storage_dir

### DIFF
--- a/recipes/carbon_cache_upstart.rb
+++ b/recipes/carbon_cache_upstart.rb
@@ -20,10 +20,11 @@
 template '/etc/init/carbon-cache.conf' do
   source 'carbon.upstart.erb'
   variables(
-    :name       => 'cache',
-    :dir        => node['graphite']['base_dir'],
-    :user       => node['graphite']['user_account'],
-    :instances  => node['graphite']['carbon']['caches']
+    :name         => 'cache',
+    :base_dir     => node['graphite']['base_dir'],
+    :storage_dir  => node['graphite']['storage_dir'],
+    :user         => node['graphite']['user_account'],
+    :instances    => node['graphite']['carbon']['caches']
   )
   mode 00644
 end

--- a/templates/default/carbon.upstart.erb
+++ b/templates/default/carbon.upstart.erb
@@ -13,7 +13,7 @@ setuid <%= @user %>
 
 pre-start script
   <% @instances.each do |instance| -%>
-  LOGDIR="<%= @dir %>/storage/log/carbon-<%= @name %>/carbon-<%= @name %>-<%= instance.first %>"
+  LOGDIR="<%= @storage_dir %>/log/carbon-<%= @name %>/carbon-<%= @name %>-<%= instance.first %>"
   [ -d $LOGDIR ] || mkdir -p $LOGDIR
   chown -R <%= @user %> $LOGDIR
   <% end -%>
@@ -21,6 +21,6 @@ end script
 
 script
   <% @instances.each do |instance| -%>
-  <%= @dir %>/bin/carbon-<%= @name %>.py --debug --instance=<%= instance.first %> start >> <%= @dir %>/storage/log/carbon-<%= @name %>/carbon-<%= @name %>-<%= instance.first %>/console.log 2>&1
+  <%= @base_dir %>/bin/carbon-<%= @name %>.py --debug --instance=<%= instance.first %> start >> <%= @storage_dir %>/log/carbon-<%= @name %>/carbon-<%= @name %>-<%= instance.first %>/console.log 2>&1
   <% end -%>
 end script


### PR DESCRIPTION
The upstart template writes it's logs to storage_dir however it does not honor node.graphite.storage_dir.
This pull request simply resolves this. 

Was looking at the init template and that one seems to long to the standard /var/log .. should this be brought into line with that instead ? 
