### PR TITLE
Use a uwsgi config file to allow more options

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -1,5 +1,15 @@
-default['graphite']['uwsgi']['socket'] = '/tmp/uwsgi.sock'
-default['graphite']['uwsgi']['workers'] = 8
-default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
-default['graphite']['uwsgi']['listen_http'] = false
 default['graphite']['uwsgi']['service_type'] = 'runit'
+
+default['graphite']['uwsgi']['config']['processes'] = 8
+default['graphite']['uwsgi']['config']['plugins'] = ['carbon']
+default['graphite']['uwsgi']['config']['carbon'] = '127.0.0.1:2003'
+default['graphite']['uwsgi']['config']['http'] = nil
+default['graphite']['uwsgi']['config']['socket'] = '/tmp/uwsgi.sock'
+default['graphite']['uwsgi']['config']['pythonpath'] = ["#{node['graphite']['base_dir']}/lib", "#{node['graphite']['base_dir']}/webapp/graphite"]
+default['graphite']['uwsgi']['config']['wsgi-file'] = "#{node['graphite']['base_dir']}/conf/graphite.wsgi.example"
+default['graphite']['uwsgi']['config']['uid'] = node['graphite']['user_account']
+default['graphite']['uwsgi']['config']['gid'] = node['graphite']['group_account']
+default['graphite']['uwsgi']['config']['procname'] = 'graphite-web'
+default['graphite']['uwsgi']['config']['no-orphans'] = true
+default['graphite']['uwsgi']['config']['master'] = true
+default['graphite']['uwsgi']['config']['die-on-term'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@hw-ops.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.8'
+version          '0.4.9'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/uwsgi_runit.rb
+++ b/recipes/uwsgi_runit.rb
@@ -2,4 +2,5 @@ include_recipe 'runit'
 
 runit_service 'graphite-web' do
   default_logger true
+  subscribes :restart, 'file[uwsgi-config]'
 end

--- a/recipes/uwsgi_upstart.rb
+++ b/recipes/uwsgi_upstart.rb
@@ -8,4 +8,5 @@ service 'graphite-web' do
   provider Chef::Provider::Service::Upstart
   supports :restart => true
   action [:enable, :start]
+  subscribes :restart, 'file[uwsgi-config]'
 end

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -1,17 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
-<% if node['graphite']['uwsgi']['carbon'] -%>
---plugins carbon --carbon <%= node['graphite']['uwsgi']['carbon'] %> \
-<% end -%>
-<% if node['graphite']['uwsgi']['listen_http'] -%>
---http :<%= node['graphite']['listen_port'] %> \
-<% end -%>
---pythonpath <%= node['graphite']['base_dir'] %>/lib \
---pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
---wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
---uid <%= node['graphite']['user_account'] %> --gid <%= node['graphite']['group_account'] %> \
---no-orphans --master \
---procname graphite-web \
---die-on-term \
---socket <%= node['graphite']['uwsgi']['socket'] %>
+exec uwsgi --json <%= node['graphite']['base_dir'] %>/conf/uwsgi-config.json

--- a/templates/default/uwsgi.upstart.erb
+++ b/templates/default/uwsgi.upstart.erb
@@ -2,19 +2,4 @@ description "uwsgi graphite instance"
 start on runlevel [2345]
 stop on runlevel [06]
 
-exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
-<% if node['graphite']['uwsgi']['carbon'] -%>
---plugins carbon --carbon 127.0.0.1:2003 \
-<% end -%>
---pythonpath <%= node['graphite']['base_dir'] %>/lib \
---pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
---wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
---uid <%= node['graphite']['user_account'] %> --gid <%= node['graphite']['group_account'] %> \
---no-orphans --master \
---procname graphite-web \
---die-on-term \
-<% if node['graphite']['uwsgi']['listen_http'] -%>
---http <%= node['graphite']['listen_ip'] unless node['graphite']['listen_ip'].nil? %>:<%= node['graphite']['listen_port'] %>
-<% else -%>
---socket <%= node['graphite']['uwsgi']['socket'] %>
-<% end -%>
+exec uwsgi --json <%= node['graphite']['base_dir'] %>/conf/uwsgi-config.json


### PR DESCRIPTION
This allows more uwsgi config options, such as `buffer-size` to allow
longer query strings. Removes restriction that options must already
exist in this cookbook to be useful.

Also simplifies the upstart and runit configs.

Requires jannson to support loading JSON configs for uwsgi.
