### PR TITLE
Fixing typo in the carbon soruce attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['graphite']['package_names'] = {
   },
   'carbon' => {
     'package' => 'carbon',
-    'source' => 'https://github.com/graphite-project/graphite-web/zipball/master'
+    'source' => 'https://github.com/graphite-project/carbon/zipball/master'
   },
   'graphite_web' => {
     'package' => 'graphite-web',


### PR DESCRIPTION
Self-explanatory, the `default['graphite']['package_names']['carbon']['source']` attribute pointed to the wrong location.
