### PR TITLE
Apache vhost no longer gets enabled by apache2 cookbook 2.0.0

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -7,7 +7,7 @@ execute 'create apache basic_auth file for graphite' do
   only_if { node['graphite']['apache']['basic_auth']['enabled'] }
 end
 
-template "#{node['apache']['dir']}/sites-available/graphite" do
+template "#{node['apache']['dir']}/sites-available/graphite.conf" do
   source 'graphite-vhost.conf.erb'
   notifies :reload, 'service[apache2]'
 end

--- a/templates/default/graphite-vhost.conf.erb
+++ b/templates/default/graphite-vhost.conf.erb
@@ -69,6 +69,6 @@ NameVirtualHost *:<%= node['graphite']['listen_port'] %>
 	# must change @DJANGO_ROOT@ to be the path to your django
 	# installation, which is probably something like:
 	# /usr/lib/python2.6/site-packages/django
-        Alias /media/ "<%= node['graphite']['django_root'] %>/contrib/admin/media/"
+    Alias /media/ "<%= node['graphite']['django_root'] %>/contrib/admin/media/"
 
 </VirtualHost>


### PR DESCRIPTION
Apologies in advance for the white-space commit.

Apache cookbook version 2.0.0 changed:

```
Include /etc/apache2/sites-enabled/
```

to

```
Include /etc/apache2/sites-enabled/*.conf
```

And made everyone sad. This PR addresses that.

It also addresses a bug bear of mine whereby Apache issues a warning on start if you have the NameVirtualHost twice.
