### PR TITLE
Changed graphite site file name in apache

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -7,12 +7,12 @@ execute 'create apache basic_auth file for graphite' do
   only_if { node['graphite']['apache']['basic_auth']['enabled'] }
 end
 
-template "#{node['apache']['dir']}/sites-available/graphite" do
+template "#{node['apache']['dir']}/sites-available/graphite.conf" do
   source 'graphite-vhost.conf.erb'
   notifies :reload, 'service[apache2]'
 end
 
-apache_site 'graphite'
+apache_site 'graphite.conf'
 
 apache_site '000-default' do
   enable false


### PR DESCRIPTION
According to apache2 cookbook (https://github.com/onehealth-cookbooks/apache2/blob/master/templates/default/apache2.conf.erb#L268) , site file name should have  .conf file-ext.

https://gist.github.com/anarcher/0a0f1d9f2d942536d34f#file-apache2-erb
