### PR TITLE
Remove an old attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,7 +21,6 @@ suites:
   attributes:
     graphite:
       listen_port: "8080"
-      web_server: "uwsgi"
       uwsgi:
         workers: 4
         listen_http: true


### PR DESCRIPTION
attribute ['graphite']['web_server'] is no more used in 1.0.x
