### PR TITLE
Add accumulator and resource for writing storage-aggregation.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ your own wrapper if you live on the edge and prefer [Ceres](https://github.com/g
 * `graphite_storage`: makes a directory intended for graphite storage,
   installs whisper
 * `graphite_storage_schema`: data driven resource for storage schema 
+* `graphite_storage_aggregation`: data driven resource for storage aggregation
 
 ### Graphite Web
 Write the configuration file for [Graphite Web](https://github.com/graphite-project/graphite-web)
@@ -136,6 +137,8 @@ to use these directly, but you're welcome to go crazy.
 * `graphite_carbon_conf_accumulator`: lookup named carbon resources in
   run context and gather config
 * `graphite_storage_conf_accumulator`: lookup named storage schema
+  resources in run context and gather config
+* `graphite_storage_aggregation_conf_accumulator`: lookup named storage aggregation
   resources in run context and gather config
 
 If you look at the

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -11,6 +11,14 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:graphite_carbon_conf_accumulator, :create, name)
   end
 
+  def create_graphite_storage_conf_accumulator(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:graphite_storage_conf_accumulator, :create, name)
+  end
+
+  def create_graphite_storage_aggregation_conf_accumulator(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:graphite_storage_aggregation_conf_accumulator, :create, name)
+  end
+
   def enable_runit_service(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:runit_service, :enable, resource_name)
   end

--- a/libraries/provider_storage_aggregation_conf_accumulator.rb
+++ b/libraries/provider_storage_aggregation_conf_accumulator.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: graphite
+# Provider:: provider_storage_aggregation_conf_accumulator
+#
+# Copyright 2014, Heavy Water Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# nod to https://github.com/kisoku/chef-accumulator for the ideas
+
+require 'chef/provider'
+
+class Chef
+  class Provider
+    class GraphiteStorageAggregationConfAccumulator < Chef::Provider
+
+      include ChefGraphite::Mixins
+
+      def whyrun_supported?
+        false
+      end
+
+      def load_current_resource
+        @current_resource = new_resource
+      end
+
+      def action_create
+        resources = run_context.resource_collection.select { |x| x.resource_name == :graphite_storage_aggregation }
+        file_resource = run_context.resource_collection.find(new_resource.file_resource)
+
+        contents = "# This file is managed by Chef, your changes *will* be overwritten!\n\n"
+        contents << ChefGraphite.ini_file(resources_to_hashes(resources))
+        file_resource.content contents
+
+        file_resource.run_action(:create)
+
+        if file_resource.updated_by_last_action?
+          new_resource.updated_by_last_action(true)
+        end
+
+      end
+    end
+  end
+end

--- a/providers/storage_aggregation.rb
+++ b/providers/storage_aggregation.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: graphite
+# Provider:: storage_aggregation
+#
+# Copyright 2014, Heavy Water Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :create do
+end

--- a/recipes/_carbon_config.rb
+++ b/recipes/_carbon_config.rb
@@ -36,3 +36,13 @@ file "storage-schemas.conf" do
 end
 
 graphite_storage_conf_accumulator "default"
+
+file "storage-aggregation.conf" do
+  path "#{node['graphite']['base_dir']}/conf/storage-aggregation.conf"
+  owner node['graphite']['user']
+  group node['graphite']['group']
+  mode 0644
+  action :nothing
+end
+
+graphite_storage_aggregation_conf_accumulator "default"

--- a/resources/storage_aggregation.rb
+++ b/resources/storage_aggregation.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: graphite
+# Resource:: storage_aggregation
+#
+# Copyright 2014, Heavy Water Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :name, :kind_of => String, :default => nil, :name_attribute => true
+attribute :config, :kind_of => Hash, :default => nil

--- a/resources/storage_aggregation_conf_accumulator.rb
+++ b/resources/storage_aggregation_conf_accumulator.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: graphite
+# Resource:: storage_aggregation_conf_accumulator
+#
+# Copyright 2014, Heavy Water Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+default_action :create
+
+attribute :name, :kind_of => String, :default => nil, :name_attribute => true
+attribute :file_resource, :kind_of => String, :default => "file[storage-aggregation.conf]"
+
+def initialize(*args)
+  super
+  @provider = Chef::Provider::GraphiteStorageAggregationConfAccumulator
+end

--- a/spec/providers/storage_aggregation_spec.rb
+++ b/spec/providers/storage_aggregation_spec.rb
@@ -1,0 +1,16 @@
+require_relative "../spec_helper"
+load_resource("graphite", "storage_aggregation")
+load_provider("graphite", "storage_aggregation")
+
+describe Chef::Provider::GraphiteStorageAggregation do
+
+  let(:resource_name) { "joe" }
+
+  it "is whyrun support" do
+    expect(provider).to be_whyrun_supported
+  end
+
+  it "for :create action, it exists" do
+    expect(provider.run_action(:create))
+  end
+end

--- a/spec/recipes/_carbon_config_spec.rb
+++ b/spec/recipes/_carbon_config_spec.rb
@@ -32,4 +32,12 @@ describe 'graphite::_carbon_config' do
     expect(chef_run).to create_graphite_carbon_conf_accumulator("default")
   end
 
+  it "to create the graphite_storage_conf_accumulator resource" do
+    expect(chef_run).to create_graphite_storage_conf_accumulator("default")
+  end
+
+  it "to create the graphite_storage_aggregation_conf_accumulator resource" do
+    expect(chef_run).to create_graphite_storage_aggregation_conf_accumulator("default")
+  end
+
 end

--- a/spec/resources/storage_aggregation_conf_accumulator_spec.rb
+++ b/spec/resources/storage_aggregation_conf_accumulator_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+load_resource("graphite", "storage_aggregation_conf_accumulator")
+require_relative "../../libraries/mixins"
+require_relative "../../libraries/provider_storage_aggregation_conf_accumulator"
+
+describe Chef::Resource::GraphiteStorageAggregationConfAccumulator do
+
+  let(:resource_name) { "foobar" }
+
+  it "sets the name attribute to name" do
+    expect(resource.name).to eq("foobar")
+  end
+
+  it "attribute file_resource defaults to file[storage-aggregation.conf]" do
+    expect(resource.file_resource).to eq("file[storage-aggregation.conf]")
+  end
+
+  it "attribute file_resource takes a String value" do
+    resource.file_resource("blahblah")
+
+    expect(resource.file_resource).to eq("blahblah")
+  end
+
+  it "action defaults to :create" do
+    expect(resource.action).to eq(:create)
+  end
+
+  it "provider defaults to GraphiteStorageConfAccumulator" do
+    expect(resource.provider).to eq(Chef::Provider::GraphiteStorageAggregationConfAccumulator)
+  end
+end

--- a/spec/resources/storage_aggregation_spec.rb
+++ b/spec/resources/storage_aggregation_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+load_resource("graphite", "storage_aggregation")
+
+describe Chef::Resource::GraphiteStorageAggregation do
+
+  let(:resource_name) { "foobar" }
+
+  it "sets the name attribute to name" do
+    expect(resource.name).to eq("foobar")
+  end
+
+  it "attribute config defaults to nil" do
+    expect(resource.config).to be_nil
+  end
+
+  it "attribute config takes a Hash value" do
+    resource.config("a" => "b")
+
+    expect(resource.config).to eq("a" => "b")
+  end
+
+  it "action defaults to :create" do
+    expect(resource.action).to eq(:create)
+  end
+
+  it "actions include :delete" do
+    expect(resource.allowed_actions).to include(:delete)
+  end
+end


### PR DESCRIPTION
First of all, thank you for the awesome rewrite of the cookbook! The accumulator pattern to generate the INI files is fantastic.

This essentially copies the functionality of the resources/providers that write out `storage.conf`, in order to provide the same pattern to write out `storage-aggregation.conf`. I found myself in need of this tonight so that I could configure `storage-aggregation.conf` [for Statsd](https://github.com/etsy/statsd/blob/master/docs/graphite.md).

Let me know if you'd like any additional testing for this, or if I'm completely off! I would also be happy to write accumulator resources for the other configuration files that aren't covered yet (in which case some additional DRYing of the accumulator code might be in order as well).
