### PR TITLE
Pointing the link in the readme to current docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 ## Description
 
-Library cookbook for installation and configuration of Graphite
-http://graphite.wikidot.com/ via Chef
+Library cookbook for installation and configuration of [Graphite](http://graphite.readthedocs.org) via Chef
 
 Consult the Graphite documentation for more information:
 


### PR DESCRIPTION
The wikidot site is actively being deprecated.  The ReadTheDocs site should be used.
