### PR TITLE
sets graphite dir perms after install

### DIFF
--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -22,6 +22,7 @@ include_recipe 'python::pip'
 
 include_recipe 'graphite::_user'
 include_recipe 'graphite::_web_packages'
+include_recipe 'graphite::_directories'
 
 basedir = node['graphite']['base_dir']
 docroot = node['graphite']['doc_root']


### PR DESCRIPTION
The `graphite::carbon` recipe modifies the owner/group on a few graphite directories after installing the carbon packages. 

``` ruby
include_recipe "graphite::_user"
include_recipe "graphite::_carbon_packages"
include_recipe "graphite::_directories"
```

The same measures should be taken when invoking the `graphite::web` recipe.

One clear example of why this is useful: The webapp, using its default local settings, will try to write a sqlite3 db to `/opt/graphite/storage`. This operation fails unless the directory owner/group has been modified.
