### PR TITLE
Updated single node example to work with custom graphite storage_dir

### DIFF
--- a/example/graphite_example/recipes/single_node.rb
+++ b/example/graphite_example/recipes/single_node.rb
@@ -2,6 +2,8 @@ include_recipe "runit"
 include_recipe "graphite::carbon"
 include_recipe "graphite::_web_packages"
 
+storage_dir = node['graphite']['storage_dir']
+
 graphite_carbon_cache "default" do
   config ({
             enable_logrotation: true,
@@ -19,7 +21,8 @@ graphite_carbon_cache "default" do
             use_flow_control: true,
             log_updates: false,
             log_cache_hits: false,
-            whisper_autoflush: false
+            whisper_autoflush: false,
+            local_data_dir: "#{storage_dir}/whisper/"
           })
 end
 
@@ -46,11 +49,11 @@ graphite_web_config "#{base_dir}/webapp/graphite/local_settings.py" do
            secret_key: "a_very_secret_key_jeah!",
            time_zone: "America/Chicago",
            conf_dir: "#{base_dir}/conf",
-           storage_dir: "#{base_dir}/storage",
+           storage_dir: storage_dir,
            databases: {
              default: {
                # keys need to be upcase here
-               NAME: "#{base_dir}/storage/graphite.db",
+               NAME: "#{storage_dir}/graphite.db",
                ENGINE: "django.db.backends.sqlite3",
                USER: nil,
                PASSWORD: nil,
@@ -62,7 +65,7 @@ graphite_web_config "#{base_dir}/webapp/graphite/local_settings.py" do
   notifies :restart, 'service[graphite-web]', :delayed
 end
 
-directory "#{base_dir}/storage/log/webapp" do
+directory "#{storage_dir}/log/webapp" do
   owner node['graphite']['user']
   group node['graphite']['group']
   recursive true
@@ -72,7 +75,7 @@ execute "python manage.py syncdb --noinput" do
   user node['graphite']['user']
   group node['graphite']['group']
   cwd "#{base_dir}/webapp/graphite"
-  creates "#{base_dir}/storage/graphite.db"
+  creates "#{storage_dir}/graphite.db"
 end
 
 # creates an initial user, doesn't require the set_admin_password


### PR DESCRIPTION
The example recipe `single_node.rb` does not respect the `node['graphite']['storage_dir']` value. So if someone overrides that value and uses that example recipe, carbon and Django are writing data to the wrong place.
