### PR TITLE
enabling an attribute for --buffer-size

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -4,3 +4,4 @@ default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
 default['graphite']['uwsgi']['listen_http'] = false
 default['graphite']['uwsgi']['port'] = 8080
 default['graphite']['uwsgi']['service_type'] = 'runit'
+default['graphite']['uwsgi']['buffer-size'] = '4096'

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -12,6 +12,7 @@ exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
 --wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
 --uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
 --no-orphans --master \
+--buffer-size <%= node['graphite']['uwsgi']['buffer-size'] %> \
 --procname graphite-web \
 --die-on-term \
 --socket <%= node['graphite']['uwsgi']['socket'] %>


### PR DESCRIPTION
Had a lot of issues with this in my installation. More info is [here.](http://uwsgi-docs.readthedocs.org/en/latest/ThingsToKnow.html)

Specifically,

> By default uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start 
> receiving “invalid request block size” in your logs, it could mean you need a bigger buffer. Increase it (up to
> 65535) with the buffer-size option.

This should allow the ability to control this. 4096 is the default. 

Let me know what you think. Thanks!
