### PR TITLE
Make the install of the graphite backend optional

### DIFF
--- a/providers/carbon_cache.rb
+++ b/providers/carbon_cache.rb
@@ -24,7 +24,9 @@ end
 use_inline_resources
 
 action :create do
-  set_updated { install_python_pip }
+  if new_resource.install 
+    set_updated { install_python_pip }
+  end 
 end
 
 def install_python_pip

--- a/providers/carbon_cache.rb
+++ b/providers/carbon_cache.rb
@@ -24,9 +24,7 @@ end
 use_inline_resources
 
 action :create do
-  if new_resource.install 
-    set_updated { install_python_pip }
-  end 
+  set_updated { install_python_pip } if new_resource.install
 end
 
 def install_python_pip

--- a/resources/carbon_cache.rb
+++ b/resources/carbon_cache.rb
@@ -22,6 +22,7 @@ default_action :create
 
 attribute :name, :kind_of => String, :default => nil, :name_attribute => true
 attribute :backend, :kind_of => [String, Hash], :default => "whisper"
+attribute :install, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :config, :kind_of => Hash, :default => nil
 
 def backend_name


### PR DESCRIPTION
If we are installing the graphite packages via another mechanism (i.e. native packages) we may want to use the graphite_carbon_cache resource just for collecting configuration. This allows for greater idempotency in subsequent cookbook runs.

By creating an optional attribute :install (defaulting to true) we can allow people to opt into the pip install logic.
