### PR TITLE
Allow uWSGI configuration entirely through attributes

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -17,9 +17,24 @@
 # limitations under the License.
 #
 
-default['graphite']['uwsgi']['socket'] = '/tmp/uwsgi.sock'
-default['graphite']['uwsgi']['workers'] = 8
-default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
-default['graphite']['uwsgi']['listen_http'] = false
-default['graphite']['uwsgi']['port'] = 8080
 default['graphite']['uwsgi']['service_type'] = 'runit'
+
+basedir = default['graphite']['base_dir']
+
+default['graphite']['uwsgi']['config'] = {
+    "processes" => 8,
+    "plugins" => [
+        "carbon --carbon 127.0.0.1:2003"
+    ],
+    "pythonpath" => [
+        "#{basedir}/lib",
+        "#{basedir}/webapp/graphite"
+    ],
+    "wsgi-file" => "#{basedir}/conf/graphite.wsgi.example",
+    "uid" => default['graphite']['user'],
+    "gid" => default['graphite']['group'],
+    "no-orphans" => true,
+    "master" => true,
+    "die-on-term" => true,
+    "socket" => "/tmp/uwsgi.sock"
+}

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -1,17 +1,20 @@
 #!/bin/sh
 exec 2>&1
-exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
-<% if node['graphite']['uwsgi']['carbon'] -%>
---plugins carbon --carbon <%= node['graphite']['uwsgi']['carbon'] %> \
+exec uwsgi \
+<% lineterm = "\\" -%>
+<% node['graphite']['uwsgi']['config'].each_with_index do |(param, val), index| -%>
+<% if index == node['graphite']['uwsgi']['config'].size - 1 -%>
+<% lineterm = "" -%>
 <% end -%>
-<% if node['graphite']['uwsgi']['listen_http'] -%>
---http :<%= node['graphite']['uwsgi']['port'] %> \
+<% if val.is_a? String -%>
+--<%= param %> <%= val %> <%= lineterm %>
+<% elsif val.is_a? Integer -%>
+--<%= param %> <%= val.to_s %> <%= lineterm %>
+<% elsif !!val == val -%>
+--<%= param %> <%= lineterm %>
+<% elsif val.is_a? Array -%>
+<% val.each do |eachval| -%>
+--<%= param %> <%= eachval %> <%= lineterm %>
 <% end -%>
---pythonpath <%= node['graphite']['base_dir'] %>/lib \
---pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
---wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
---uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
---no-orphans --master \
---procname graphite-web \
---die-on-term \
---socket <%= node['graphite']['uwsgi']['socket'] %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
This is necessary because uWSGI has many flags, which exceed the scope of
this cookbook. Instead of supporting every single possible flag with logic,
support any possibility with attributes, override attributes, and the like.

One single hash contains all the information for the uWSGI configuration file.

Example:
The key is rendered as '--flag' and the value is rendered as 'val'
EG: default['graphite']['uwsgi']['config']['key'] = 'val'
--key val

Integers are cast to strings

Arrays repeat the flag name, such as
default['graphite']['uwsgi']['config']['pythonpath'] = [foo, bar]
--pythonpath foo
--pythonpath bar

If a value is set to Boolean type true, the flag is simply stated
EG: default['graphite']['uwsgi']['config']['master'] = true
--master
