### PR TITLE
Use poise-python cookbook instead of deprecated python cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,5 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'poise-python', '~> 1.5.1'
-
 metadata
 
 group :integration do

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,7 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'poise-python', '~> 1.5.1'
+
 metadata
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Consult the Graphite documentation for more information:
 
 ### Cookbooks
 
-- python
+- poise-python
 - runit
 - build-essential
 - yum-epel

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ supports 'amazon'
 supports 'scientific'
 supports 'oracle'
 
-depends  'poise-python', '~> 1.5.1'
+depends  'poise-python', '>= 1.5'
 depends  'runit', '>= 1.2'
 depends  'build-essential'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ supports 'amazon'
 supports 'scientific'
 supports 'oracle'
 
-depends  'python'
+depends  'poise-python'
 depends  'runit', '>= 1.2'
 depends  'build-essential'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ supports 'amazon'
 supports 'scientific'
 supports 'oracle'
 
-depends  'poise-python'
+depends  'poise-python', '~> 1.5.1'
 depends  'runit', '>= 1.2'
 depends  'build-essential'
 

--- a/recipes/_carbon_packages.rb
+++ b/recipes/_carbon_packages.rb
@@ -21,11 +21,11 @@ include_recipe 'build-essential'
 
 # sadly, have to pin Twisted to known good version
 # install before carbon so it's used
-python_pip 'Twisted' do
+python_package 'Twisted' do
   version lazy { node['graphite']['twisted_version'] }
 end
 
-python_pip 'carbon' do
+python_package 'carbon' do
   package_name lazy {
     node['graphite']['package_names']['carbon'][node['graphite']['install_type']]
   }

--- a/recipes/_web_packages.rb
+++ b/recipes/_web_packages.rb
@@ -21,28 +21,28 @@ Array(node['graphite']['system_packages']).each do |p|
   package p
 end
 
-python_pip 'django' do
+python_package 'django' do
   version lazy { node['graphite']['django_version'] }
 end
 
 # The latest version is 0.4, which causes an importError
 # ImportError: No module named fields
 # with `python manage.py syncdb --noinput`
-python_pip 'django-tagging' do
+python_package 'django-tagging' do
   version '0.3.6'
 end
 
-python_pip 'pytz'
-python_pip 'pyparsing'
-python_pip 'python-memcached'
+python_package 'pytz'
+python_package 'pyparsing'
+python_package 'python-memcached'
 
-python_pip 'uwsgi' do
+python_package 'uwsgi' do
   options '--isolated'
 end
 
-python_pip 'cairocffi'
+python_package 'cairocffi'
 
-python_pip 'graphite_web' do
+python_package 'graphite_web' do
   package_name lazy {
     key = node['graphite']['install_type']
     node['graphite']['package_names']['graphite_web'][key]

--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -17,8 +17,11 @@
 # limitations under the License.
 #
 
-include_recipe 'python'
-include_recipe 'python::pip'
+python_runtime 'carbon' do
+  provider :system
+  version '2.7'
+  options pip_version: true
+end
 
 include_recipe 'graphite::_user'
 include_recipe 'graphite::_carbon_packages'

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -17,8 +17,11 @@
 # limitations under the License.
 #
 
-include_recipe 'python'
-include_recipe 'python::pip'
+python_runtime 'web' do
+  provider :system
+  version '2.7'
+  options pip_version: true
+end
 
 include_recipe 'graphite::_user'
 include_recipe 'graphite::_web_packages'


### PR DESCRIPTION
As you know, [python](https://github.com/poise/python) cookbook is deprecated and [poise-python](https://github.com/poise/poise-python) is current cookbook.

According to https://github.com/poise/poise-python#upgrading-from-the-python-cookbook , we can migrate to use poise-python feature with roughly equivalent. In my environment (centos7), it works as below recipes.

* include_recipe 'graphite::packages'
* include_recipe 'graphite::carbon'
* nclude_recipe 'graphite::web'
