### PR TITLE
Remove unnecessary actions method in the resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ran linters and addressed issues
 - Ran latest cookstyle
+- Remove unnecessary actions method in the resources
 
 ## [1.1.0] - 2019-09-05
 

--- a/resources/carbon_aggregator.rb
+++ b/resources/carbon_aggregator.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-actions :create, :delete
 default_action :create
 
 attribute :config, kind_of: Hash, default: nil

--- a/resources/carbon_conf_accumulator.rb
+++ b/resources/carbon_conf_accumulator.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-actions :create
 default_action :create
 
 attribute :file_resource, kind_of: String, default: 'file[carbon.conf]'

--- a/resources/carbon_relay.rb
+++ b/resources/carbon_relay.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-actions :create, :delete
 default_action :create
 
 attribute :config, kind_of: Hash

--- a/resources/storage_conf_accumulator.rb
+++ b/resources/storage_conf_accumulator.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-actions :create
 default_action :create
 
 attribute :file_resource, kind_of: String, default: 'file[storage-schemas.conf]'

--- a/resources/storage_schema.rb
+++ b/resources/storage_schema.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-actions :create, :delete
 default_action :create
 
 attribute :config, kind_of: Hash, default: nil


### PR DESCRIPTION
This is done automatically. No need to define it again.

Signed-off-by: Tim Smith <tsmith@chef.io>