### PR TITLE
Ruby 2.7 Core Methods Return Frozen Strings Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.2.0 (2020-05-27) 
+## 1.2.0 (2020-05-27)
 
 - Fix Django/Twisted overridden version ([#318])
 

--- a/libraries/chef_graphite.rb
+++ b/libraries/chef_graphite.rb
@@ -75,7 +75,7 @@ module ChefGraphite
         obj.map { |o| normalize_value(o) }.join(', ')
       else
         value = obj.to_s
-        value.capitalize! if %w(true false).include?(value)
+        value = value.capitalize if %w(true false).include?(value)
         value
       end
     end


### PR DESCRIPTION
## Description

I'm in the process of upgrading to Cinc/Chef 16 and I ran into an error:

```
Recipe: graphite::_carbon_config
  * directory[conf dir] action create (up to date)
  * file[carbon.conf] action nothing (skipped due to action :nothing)
  * graphite_carbon_conf_accumulator[default] action create

    ================================================================================
    Error executing action `create` on resource 'graphite_carbon_conf_accumulator[default]'
    ================================================================================

    FrozenError
    -----------
    can't modify frozen String: "true"

    Cookbook Trace:
    ---------------
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:78:in `capitalize!'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:78:in `normalize_value'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:68:in `block in normalize'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:67:in `each'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:67:in `normalize'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:50:in `block in section_tuples'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:47:in `map'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:47:in `section_tuples'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:35:in `generate_conf_data'
    /opt/kitchen/cache/cookbooks/graphite/libraries/chef_graphite.rb:23:in `ini_file'
    /opt/kitchen/cache/cookbooks/graphite/libraries/provider_carbon_conf_accumulator.rb:44:in `action_create'

    Resource Declaration:
    ---------------------
    # In /opt/kitchen/cache/cookbooks/graphite/recipes/_carbon_config.rb

     36: graphite_carbon_conf_accumulator 'default' do
     37:   sort_configs node['graphite']['sort_configs']
     38: end
     39:

    Compiled Resource:
    ------------------
    # Declared in /opt/kitchen/cache/cookbooks/graphite/recipes/_carbon_config.rb:36:in `from_file'

    graphite_carbon_conf_accumulator("default") do
      provider Chef::Provider::GraphiteCarbonConfAccumulator
      action [:create]
      default_guard_interpreter :default
      declared_type :graphite_carbon_conf_accumulator
      cookbook_name "graphite"
      recipe_name "_carbon_config"
      sort_configs true
    end

    System Info:
    ------------
    chef_version=16.0.257
    platform=ubuntu
    platform_version=18.04
    ruby=ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
    program_name=/opt/chef/bin/chef-client
    executable=/opt/chef/bin/cinc-client
```

In Ruby 2.7 core methods now return a frozen string: https://rubyreferences.github.io/rubychanges/2.7.html#core-methods-returning-frozen-strings

The Ruby change produced the above error I ran into.  This PR fixes the error by not attempting to update the frozen string itself.

I'm not sure how to write a test for this with the existing suite since it would require testing against multiple versions of Chef. It looks like it's testing against Chef16 and is failing on poise-python which isn't related to my change

### Issues Resolved

No existing issue for this bug that I could find on this repo.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
